### PR TITLE
fix: Resolved Azure OpenAI Service configuration variables

### DIFF
--- a/tinytroupe/openai_utils.py
+++ b/tinytroupe/openai_utils.py
@@ -365,9 +365,9 @@ class AzureClient(OpenAIClient):
         Sets up the Azure OpenAI Service API configurations for this client,
         including the API endpoint and key.
         """
-        self.client = AzureOpenAI(azure_endpoint= os.getenv("AZURE_OPENAI_ENDPOINT"),
+        self.client = AzureOpenAI(azure_endpoint= config["OpenAI"]["AZURE_OPENAI_ENDPOINT"],
                                   api_version = config["OpenAI"]["AZURE_API_VERSION"],
-                                  api_key = os.getenv("AZURE_OPENAI_KEY"))
+                                  api_key = config["OpenAI"]["AZURE_OPENAI_KEY"])
     
     def _raw_model_call(self, model, chat_api_params):
         """


### PR DESCRIPTION
# Human Summary
I made it because there is an mistake from your codebase and this effects Azure OpenAI user like us. I just changed, `os.getenv` with `config["OpenAI"]`. 


# AI Summary
This pull request includes changes to the `tinytroupe/openai_utils.py` file to improve the configuration setup for the Azure OpenAI Service API. The most important change is the modification of the `_setup_from_config` method to use configuration values from a `config` dictionary instead of environment variables.

Configuration improvements:

* [`tinytroupe/openai_utils.py`](diffhunk://#diff-0bb7fe42f662e8bd41416c2b2e04fe528f09e711356682248fad42ab9096afdfL368-R370): Modified the `_setup_from_config` method to use `config["OpenAI"]["AZURE_OPENAI_ENDPOINT"]`, `config["OpenAI"]["AZURE_API_VERSION"]`, and `config["OpenAI"]["AZURE_OPENAI_KEY"]` instead of environment variables for setting up the Azure OpenAI Service API.