### PR TITLE
fix typo, call `semantic_memory` method of agent not self

### DIFF
--- a/tinytroupe/agent.py
+++ b/tinytroupe/agent.py
@@ -1398,7 +1398,7 @@ class FilesAndWebGroundingFaculty(TinyMentalFaculty):
             return True
         
         elif action['type'] == "LIST_DOCUMENTS" and action['content'] is not None:
-            documents_names = self.semantic_memory.list_documents_names()
+            documents_names = agent.semantic_memory.list_documents_names()
 
             if len(documents_names) > 0:
                 agent.think(f"I have the following documents available to me: {documents_names}")


### PR DESCRIPTION
Agents' `LIST_DOCUMENTS` faculty fails because of a typo.

Call the `semantic_memory` method on the `agent` instead of `self` lets this faculty work as expected