### PR TITLE
also retry aux_act_once upon TypeError

### DIFF
--- a/tinytroupe/agent.py
+++ b/tinytroupe/agent.py
@@ -422,7 +422,8 @@ class TinyPerson(JsonSerializableRegistry):
 
         # Aux function to perform exactly one action.
         # Occasionally, the model will return JSON missing important keys, so we just ask it to try again
-        @repeat_on_error(retries=5, exceptions=[KeyError])
+        # Sometimes `content` contains EpisodicMemory's MEMORY_BLOCK_OMISSION_INFO message, which raises a TypeError on line 443
+        @repeat_on_error(retries=5, exceptions=[KeyError, TypeError])
         def aux_act_once():
             # A quick thought before the action. This seems to help with better model responses, perhaps because
             # it interleaves user with assistant messages.


### PR DESCRIPTION
Sometimes, the `content` returned by calling `self._produce_message()` within the `aux_act_once` function just contains the `MEMORY_BLOCK_OMISSION_INFO` string defined in `EpisodicMemory`
This raises a `TypeError` when attempting to access the expected dictionary items from `content`.

By adding TypeError to the `repeat_on_error` decorator, this failure can be avoided