### PR TITLE
Fix omission information control in EpisodicMemory

### DIFF
--- a/tinytroupe/agent/memory.py
+++ b/tinytroupe/agent/memory.py
@@ -131,11 +131,11 @@ class EpisodicMemory(TinyMemory):
 
         # use the other methods in the class to implement
         if first_n is not None and last_n is not None:
-            return self.retrieve_first(first_n) + omisssion_info + self.retrieve_last(last_n)
+            return self.retrieve_first(first_n, False) + omisssion_info + self.retrieve_last(last_n, False)
         elif first_n is not None:
-            return self.retrieve_first(first_n)
+            return self.retrieve_first(first_n, include_omission_info)
         elif last_n is not None:
-            return self.retrieve_last(last_n)
+            return self.retrieve_last(last_n, include_omission_info)
         else:
             return self.retrieve_all()
 


### PR DESCRIPTION
### Fix omission information control in EpisodicMemory

Hey team,

I found one bug in EpisodicMemory.
I've fixed omission information control, pls check it. 🙏
As both `retrieve_first` and `retrieve_first` have `include_omission_info` flag with the default value `True`, we have to pass correctly.