### PR TITLE
with multiprocessing, pickle issue with client.beta.chat.completions parse output

### DIFF
--- a/tinytroupe/openai_utils.py
+++ b/tinytroupe/openai_utils.py
@@ -497,7 +497,7 @@ class OpenAIClient:
 
             del chat_api_params["stream"]
 
-            return self.client.beta.chat.completions.parse(
+            return self.client.chat.completions.parse(
                     **chat_api_params
                 )
         


### PR DESCRIPTION
Reference https://github.com/openai/openai-python/issues/1776

Got this in databricks log:
```
2025-06-16 11:53:47,951 - tinytroupe - ERROR - [1] Error: Can't pickle <class 'openai.types.chat.parsed_chat_completion.ParsedChatCompletion[NoneType]'>: attribute lookup ParsedChatCompletion[NoneType] on openai.types.chat.parsed_chat_completion failed
```

enabling cache has following error
```
File /local_disk0/.ephemeral_nfs/envs/pythonEnv-ee201127-080b-45bd-92c7-3a51ea311c23/lib/python3.11/site-packages/tinytroupe/agent/tiny_person.py:427, in TinyPerson.act(self, until_done, n, return_actions, max_content_length)
    415 """
    416 Acts in the environment and updates its internal cognitive state.
    417 Either acts until the agent is done and needs additional stimuli, or acts a fixed number of times,
   (...)
    423     return_actions (bool): Whether to return the actions or not. Defaults to False.
    424 """
    426 # either act until done or act a fixed number of times, but not both
--> 427 assert not (until_done and n is not None)
    428 if n is not None:
    429     assert n < TinyPerson.MAX_ACTIONS_BEFORE_DONE
```