### PR TITLE
feat/agent-urgency-logic

### DIFF
--- a/tinytroupe/control.py
+++ b/tinytroupe/control.py
@@ -7,9 +7,13 @@ import tempfile
 
 import tinytroupe
 import tinytroupe.utils as utils
+from tinytroupe.agent.tiny_person import TinyPerson # Added import
+from typing import TYPE_CHECKING # Added import
 
 import logging
 logger = logging.getLogger("tinytroupe")
+
+URGENCY_TO_ACT_THRESHOLD = 75
 
 class Simulation:
 
@@ -642,3 +646,22 @@ def cache_misses(id="default"):
     return _simulation(id).cache_misses
     
 reset() # initialize the control state
+
+
+if TYPE_CHECKING:
+    from tinytroupe.agent.tiny_person import TinyPerson
+
+def handle_agent_action_with_urgency(agent: 'TinyPerson', observation: str):
+    # URGENCY_TO_ACT_THRESHOLD is defined in this module
+
+    # Ensure agent has the _calculate_interaction_urgency method.
+    # This function assumes it's being called with a fully capable TinyPerson instance.
+    urgency = agent._calculate_interaction_urgency(observation)
+
+    print(f"Agent {agent.name}: Urgency = {urgency} for observation '{observation}'")
+
+    if urgency >= URGENCY_TO_ACT_THRESHOLD:
+        print(f"Agent {agent.name} acts.")
+        agent.act()  # Call the existing act method on the agent
+    else:
+        print(f"Agent {agent.name} does not act.")


### PR DESCRIPTION
feat: Implement agent interaction urgency logic

This commit introduces a new mechanism for me to decide whether to act based on an urgency score.

Key changes:

1.  Added a method to calculate interaction urgency. This method:
    *   Takes an observation string.
    *   Retrieves relevant memories.
    *   Constructs a prompt with my persona, mental state, memories, and the observation.
    *   Calls an LLM to get an integer urgency score (0-100).
    *   Returns the calculated score.

2.  Defined an urgency threshold (defaulting to 75).

3.  Added a new utility function to handle my actions with urgency. This function:
    *   Calls my method to calculate interaction urgency.
    *   Prints my name, urgency score, and observation.
    *   If the urgency score meets or exceeds the threshold, my `act()` method is called.
    *   Includes print statements for observability of my decision.

This change allows for more nuanced behavior, where I only expend resources to act if the situation is deemed sufficiently urgent. The main simulation loop can now use this new utility function to process my turn.