### PR TITLE
Add pricing change customer response example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .llmapi.bin
 *.cache.*
 tests_cache.pickle
+openai_api_cache.json
 *.local.*
 .VSCodeCounter/
 .vscode/

--- a/examples/Pricing Change Customer Response Simulation.ipynb
+++ b/examples/Pricing Change Customer Response Simulation.ipynb
@@ -1,0 +1,463 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "80f14e3c",
+   "metadata": {},
+   "source": [
+    "# Simulating Customer Response to a Pricing Change\n",
+    "\n",
+    "How do different customer segments react when a SaaS product raises its price?\n",
+    "\n",
+    "This notebook demonstrates how to use TinyTroupe to simulate the responses of four distinct customer personas to a 50% price increase — from **\\$12/month to \\$18/month** — for a fictional productivity SaaS product called **FlowDesk**.\n",
+    "\n",
+    "**What you will learn:**\n",
+    "- How to define reusable personas as JSON files and load them with `TinyPerson.load_specification()`\n",
+    "- How to deliver a scenario to all agents simultaneously using `TinyWorld.broadcast()`\n",
+    "- How to extract structured, multi-field insights using `ResultsExtractor`\n",
+    "- How to analyze churn risk and feature requests across customer segments\n",
+    "\n",
+    "**Scientific framing:** Price sensitivity is shaped by reference price anchoring (Kahneman & Tversky, 1979), perceived value relative to alternatives (Monroe, 1990), and loss aversion — a 50% increase is framed as a significant loss, and losses loom larger than equivalent gains in human decision-making. Expect asymmetric reactions across personas based on income elasticity and switching cost.\n",
+    "\n",
+    "**Prerequisites:** This notebook requires an OpenAI API key (or Azure OpenAI credentials) configured in `config.ini`. See the main [TinyTroupe README](../README.md) for setup instructions. All product names and personas in this example are entirely fictional."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dccf3744",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "sys.path.insert(0, '..')\n",
+    "\n",
+    "import tinytroupe\n",
+    "from tinytroupe.agent import TinyPerson\n",
+    "from tinytroupe.environment import TinyWorld\n",
+    "from tinytroupe.validation import TinyPersonValidator\n",
+    "from tinytroupe.extraction import ResultsExtractor\n",
+    "import tinytroupe.control as control"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98769762",
+   "metadata": {},
+   "source": [
+    "## Product & Scenario\n",
+    "\n",
+    "**Product:** FlowDesk — a fictional productivity SaaS combining task management, time tracking, and lightweight project collaboration.\n",
+    "\n",
+    "**Pricing change:** Monthly subscription increases from **\\$12/month to \\$18/month** (a 50% increase), announced by email with one billing cycle of notice.\n",
+    "\n",
+    "We simulate four customer types who differ on income sensitivity, switching cost, usage intensity, and trust in the vendor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f91f842",
+   "metadata": {},
+   "source": [
+    "## Customer Personas\n",
+    "\n",
+    "Four personas designed to capture meaningfully different segments of a productivity SaaS customer base. Each is defined in a JSON file under `./agents/` and loaded with `TinyPerson.load_specification()` — the same pattern used by the built-in Oscar and Lisa agents.\n",
+    "\n",
+    "| Persona | Age | Role | Monthly budget pressure | Switching cost |\n",
+    "|---------|-----|------|------------------------|----------------|\n",
+    "| Maya Chen | 27 | Solo freelancer | Very high (variable income) | Low |\n",
+    "| Raj Patel | 34 | Startup founder | High (limited runway) | Medium |\n",
+    "| Sarah Kim | 41 | Enterprise PM | Low (expense account) | High |\n",
+    "| Ethan Brooks | 22 | Grad student | Very high (student income) | Very low |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7efe0209",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load each persona from its JSON specification in ./agents/\n",
+    "# This is the same pattern as create_oscar_the_architect() in tinytroupe/examples/agents.py\n",
+    "maya  = TinyPerson.load_specification('./agents/MayaChen.agent.json')\n",
+    "raj   = TinyPerson.load_specification('./agents/RajPatel.agent.json')\n",
+    "sarah = TinyPerson.load_specification('./agents/SarahKim.agent.json')\n",
+    "ethan = TinyPerson.load_specification('./agents/EthanBrooks.agent.json')\n",
+    "\n",
+    "all_personas = [maya, raj, sarah, ethan]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3613e695",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect each persona to confirm they loaded correctly before running the simulation\n",
+    "for persona in all_personas:\n",
+    "    persona.minibio()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd6d756d",
+   "metadata": {},
+   "source": [
+    "## Simulation Setup\n",
+    "\n",
+    "We place all four personas in a shared `TinyWorld` with `broadcast_if_no_target=False`. This means each agent receives the same scenario and responds independently — we are **not** simulating a group discussion, but four parallel individual reactions to the same announcement. This is the correct setup for individual customer research.\n",
+    "\n",
+    "Simulation caching via `control.begin()` avoids redundant API calls on repeated runs. The `.cache.` naming convention marks the cache file as non-committable (see `.gitignore`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fca78195",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to cache the simulation and avoid rerunning expensive API calls\n",
+    "# control.begin(\"pricing_change_simulation.cache.json\")\n",
+    "\n",
+    "# broadcast_if_no_target=False: each agent reacts independently, not as a group\n",
+    "world = TinyWorld('FlowDesk Customer Panel', all_personas, broadcast_if_no_target=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4eeb6f6",
+   "metadata": {},
+   "source": [
+    "## Scenario Delivery\n",
+    "\n",
+    "We deliver the scenario in three parts:\n",
+    "1. **Product context** — orient each persona as a paying FlowDesk customer\n",
+    "2. **Pricing announcement** — the actual email they received\n",
+    "3. **Reflection primer** — an inner monologue broadcast via `broadcast_thought()` that encourages honest, in-character reasoning rather than a surface reaction\n",
+    "\n",
+    "Then we run one simulation step, which causes each agent to act based on everything they have heard and thought."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db0eb19c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "product_context = (\n",
+    "    'You are a paying customer of FlowDesk, a productivity SaaS tool you have been using '\n",
+    "    'for the past year. FlowDesk helps you manage tasks, track time, and collaborate on '\n",
+    "    'projects. You currently pay $12/month and have integrated it into your daily workflow.'\n",
+    ")\n",
+    "\n",
+    "pricing_announcement = (\n",
+    "    'You just received this email from FlowDesk:\\n\\n'\n",
+    "    'Subject: Important update to your FlowDesk subscription\\n\\n'\n",
+    "    'Hi there,\\n\\n'\n",
+    "    'We are writing to let you know that starting next billing cycle, your FlowDesk '\n",
+    "    'monthly subscription will increase from $12/month to $18/month. This change reflects '\n",
+    "    'our ongoing investment in new collaboration features, a redesigned mobile app, and '\n",
+    "    'faster customer support.\\n\\n'\n",
+    "    'Your account, data, and current plan features remain unchanged. If you have '\n",
+    "    'questions, our support team is here to help.\\n\\n'\n",
+    "    'Thank you for being a FlowDesk customer.\\n'\n",
+    "    '\\u2014 The FlowDesk Team\\n\\n'\n",
+    "    'How do you feel about this? What will you do?'\n",
+    ")\n",
+    "\n",
+    "# Inject an inner monologue to encourage honest, nuanced reflection rather than a\n",
+    "# surface reaction. broadcast_thought() delivers this as an internal thought, not\n",
+    "# as a message from another agent.\n",
+    "reflection_primer = (\n",
+    "    'I will think carefully and honestly about this situation. I will consider: '\n",
+    "    'how much I actually use and value FlowDesk, how $6/month more fits into my budget, '\n",
+    "    'whether I trust this company and its communication, whether I would look for '\n",
+    "    'alternatives, and what specific improvements I would need to see to feel the '\n",
+    "    'price increase is justified. I will not give a polite or generic answer '\n",
+    "    '\\u2014 I will respond as I genuinely would in real life.'\n",
+    ")\n",
+    "\n",
+    "world.broadcast(product_context)\n",
+    "world.broadcast(pricing_announcement)\n",
+    "world.broadcast_thought(reflection_primer)\n",
+    "world.run(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1206a189",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preview each agent's raw response before structured extraction.\n",
+    "# This is useful for understanding what the LLM produced and for debugging\n",
+    "# extraction issues when field values come back as N/A.\n",
+    "for persona in all_personas:\n",
+    "    print(persona.pretty_current_interactions(max_content_length=500))\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d72a53ca",
+   "metadata": {},
+   "source": [
+    "## Persona Validation (Optional)\n",
+    "\n",
+    "We can spot-check Maya — a price-sensitive persona — using `TinyPersonValidator`. This iteratively questions the agent and returns a confidence score (0–1) indicating how well the agent's behavior matches our expectations. A high score confirms the persona definition is producing coherent, realistic responses.\n",
+    "\n",
+    "This step is disabled by default because it makes additional API calls. Set `RUN_PERSONA_VALIDATION = True` in the next cell if you want to run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1f9a7b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maya_expectations = \"\"\"\n",
+    "Maya is:\n",
+    "- Budget-sensitive and cost-conscious — tracks every subscription expense\n",
+    "- A freelancer with variable monthly income around $4,000-$5,000\n",
+    "- Aware of free and cheaper alternatives (Notion, Trello, Toggl)\n",
+    "- Not emotionally attached to FlowDesk -- pragmatic about switching\n",
+    "\n",
+    "Expected behavior on a 50% price increase:\n",
+    "- Expresses frustration or concern about the cost increase\n",
+    "- Considers or explicitly mentions cancellation or switching to an alternative\n",
+    "- Requests a justification, discount, or annual billing option to stay\n",
+    "- Is unlikely to simply accept the price increase without any pushback\n",
+    "\"\"\"\n",
+    "\n",
+    "RUN_PERSONA_VALIDATION = False\n",
+    "\n",
+    "if RUN_PERSONA_VALIDATION:\n",
+    "    maya_score, maya_justification = TinyPersonValidator.validate_person(\n",
+    "        maya,\n",
+    "        expectations=maya_expectations,\n",
+    "        include_agent_spec=True,\n",
+    "        max_content_length=None\n",
+    "    )\n",
+    "\n",
+    "    print(f\"Maya validation score: {maya_score:.2f} / 1.0\")\n",
+    "    print(f\"Justification: {maya_justification}\")\n",
+    "else:\n",
+    "    print(\"Persona validation skipped. Set RUN_PERSONA_VALIDATION = True to run it.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "411aa108",
+   "metadata": {},
+   "source": [
+    "## Extract Results\n",
+    "\n",
+    "`ResultsExtractor` uses an LLM to parse each agent's interaction history and pull structured data into the fields we define. Precise `fields_hints` are critical: they constrain the LLM to produce consistently formatted values (e.g., integer 1–5 scales, fixed categorical labels) that can be reliably compared across personas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d80b1307",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_extractor = ResultsExtractor(\n",
+    "    extraction_objective=(\n",
+    "        'Determine how the customer persona responded to a 50% price increase '\n",
+    "        '($12/month to $18/month) for a productivity SaaS called FlowDesk. '\n",
+    "        'Extract their switching risk, likelihood to continue, likelihood to churn, '\n",
+    "        'likelihood to recommend, any specific product improvements they requested, '\n",
+    "        'and their overall reaction.'\n",
+    "    ),\n",
+    "    situation=(\n",
+    "        'The agent received an email announcing a price increase from $12 to $18/month '\n",
+    "        'and was asked to respond honestly and in character.'\n",
+    "    ),\n",
+    "    fields=[\n",
+    "        'name',\n",
+    "        'switching_risk',\n",
+    "        'likelihood_to_continue',\n",
+    "        'likelihood_to_churn',\n",
+    "        'likelihood_to_recommend',\n",
+    "        'requested_improvements',\n",
+    "        'overall_reaction',\n",
+    "    ],\n",
+    "    fields_hints={\n",
+    "        'switching_risk': (\n",
+    "            'One of: Very High, High, Medium, Low, Very Low. '\n",
+    "            'Very High means almost certain to leave; Very Low means extremely unlikely.'\n",
+    "        ),\n",
+    "        'likelihood_to_continue': (\n",
+    "            'Integer 1-5. 1 = will definitely cancel, 5 = will definitely keep paying. '\n",
+    "            'Use N/A if truly indeterminate.'\n",
+    "        ),\n",
+    "        'likelihood_to_churn': (\n",
+    "            'Integer 1-5. 1 = will definitely stay, 5 = will definitely cancel. '\n",
+    "            'Use N/A if truly indeterminate.'\n",
+    "        ),\n",
+    "        'likelihood_to_recommend': (\n",
+    "            'Integer 1-5. 1 = would never recommend, 5 = would strongly recommend. '\n",
+    "            'Use N/A if truly indeterminate.'\n",
+    "        ),\n",
+    "        'requested_improvements': (\n",
+    "            'Comma-separated list of specific product changes the persona mentioned. '\n",
+    "            'Write \"None mentioned\" if no specific improvements were requested.'\n",
+    "        ),\n",
+    "        'overall_reaction': (\n",
+    "            'One of: Strongly Positive, Positive, Neutral, Negative, Strongly Negative.'\n",
+    "        ),\n",
+    "    },\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f34b9a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = results_extractor.extract_results_from_agents(world.agents)\n",
+    "\n",
+    "# Filter to valid dict results only\n",
+    "filtered_results = [r for r in results if isinstance(r, dict)]\n",
+    "\n",
+    "df = pd.DataFrame(filtered_results)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18ae2e17",
+   "metadata": {},
+   "source": [
+    "## Analysis\n",
+    "\n",
+    "We visualize three key behavioral intent scores across all four customer segments, then print a structured per-persona summary of all extracted dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92a684d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "# Colors encode expected churn risk consistently across all three charts:\n",
+    "# red = high risk (Maya, Ethan), orange = medium (Raj), blue = low (Sarah)\n",
+    "persona_colors = ['#e74c3c', '#e67e22', '#3498db', '#e74c3c']\n",
+    "\n",
+    "# Churn likelihood by persona\n",
+    "churn_data = df[[\"name\", \"likelihood_to_churn\"]].copy()\n",
+    "churn_data[\"likelihood_to_churn\"] = pd.to_numeric(\n",
+    "    churn_data[\"likelihood_to_churn\"].replace(\"N/A\", None), errors=\"coerce\"\n",
+    ")\n",
+    "churn_data = churn_data.dropna()\n",
+    "axes[0].bar(churn_data[\"name\"], churn_data[\"likelihood_to_churn\"],\n",
+    "            color=persona_colors[:len(churn_data)])\n",
+    "axes[0].set_title(\"Churn Likelihood\\n(1 = Stay, 5 = Leave)\")\n",
+    "axes[0].set_ylabel(\"Score (1-5)\")\n",
+    "axes[0].set_ylim(0, 5.5)\n",
+    "axes[0].tick_params(axis=\"x\", rotation=20)\n",
+    "\n",
+    "# Likelihood to continue\n",
+    "continue_data = df[[\"name\", \"likelihood_to_continue\"]].copy()\n",
+    "continue_data[\"likelihood_to_continue\"] = pd.to_numeric(\n",
+    "    continue_data[\"likelihood_to_continue\"].replace(\"N/A\", None), errors=\"coerce\"\n",
+    ")\n",
+    "continue_data = continue_data.dropna()\n",
+    "axes[1].bar(continue_data[\"name\"], continue_data[\"likelihood_to_continue\"],\n",
+    "            color=persona_colors[:len(continue_data)])\n",
+    "axes[1].set_title(\"Likelihood to Continue\\n(1 = Cancel, 5 = Stay)\")\n",
+    "axes[1].set_ylabel(\"Score (1-5)\")\n",
+    "axes[1].set_ylim(0, 5.5)\n",
+    "axes[1].tick_params(axis=\"x\", rotation=20)\n",
+    "\n",
+    "# Likelihood to recommend\n",
+    "recommend_data = df[[\"name\", \"likelihood_to_recommend\"]].copy()\n",
+    "recommend_data[\"likelihood_to_recommend\"] = pd.to_numeric(\n",
+    "    recommend_data[\"likelihood_to_recommend\"].replace(\"N/A\", None), errors=\"coerce\"\n",
+    ")\n",
+    "recommend_data = recommend_data.dropna()\n",
+    "axes[2].bar(recommend_data[\"name\"], recommend_data[\"likelihood_to_recommend\"],\n",
+    "            color=persona_colors[:len(recommend_data)])\n",
+    "axes[2].set_title(\"Likelihood to Recommend\\n(1 = Never, 5 = Strongly)\")\n",
+    "axes[2].set_ylabel(\"Score (1-5)\")\n",
+    "axes[2].set_ylim(0, 5.5)\n",
+    "axes[2].tick_params(axis=\"x\", rotation=20)\n",
+    "\n",
+    "plt.suptitle(\n",
+    "    \"FlowDesk Price Increase: Customer Response by Persona\",\n",
+    "    fontsize=13, fontweight=\"bold\"\n",
+    ")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c702d50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"=\" * 70)\n",
+    "print(\"FLOWDESK PRICING CHANGE -- PERSONA RESPONSE SUMMARY\")\n",
+    "print(\"=\" * 70)\n",
+    "\n",
+    "for _, row in df.iterrows():\n",
+    "    print(f'\\n{row.get(\"name\", \"Unknown\")}')\n",
+    "    print(f'  Switching risk     : {row.get(\"switching_risk\", \"N/A\")}')\n",
+    "    print(f'  Likelihood to stay : {row.get(\"likelihood_to_continue\", \"N/A\")} / 5')\n",
+    "    print(f'  Likelihood to churn: {row.get(\"likelihood_to_churn\", \"N/A\")} / 5')\n",
+    "    print(f'  Likelihood to rec. : {row.get(\"likelihood_to_recommend\", \"N/A\")} / 5')\n",
+    "    print(f'  Overall reaction   : {row.get(\"overall_reaction\", \"N/A\")}')\n",
+    "    print(f'  Requested changes  : {row.get(\"requested_improvements\", \"N/A\")}')\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 70)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cae8291c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# control.end()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/agents/EthanBrooks.agent.json
+++ b/examples/agents/EthanBrooks.agent.json
@@ -1,0 +1,107 @@
+{
+    "type": "TinyPerson",
+    "persona": {
+        "name": "Ethan Brooks",
+        "age": 22,
+        "gender": "Male",
+        "nationality": "American",
+        "residence": "Columbus, OH, USA",
+        "education": "Currently completing an MS in Computer Science at Ohio State University. BA in Computer Science from the same institution. Teaching assistant for an introductory algorithms course.",
+        "long_term_goals": [
+            "Complete his master's thesis on distributed systems and graduate within 18 months.",
+            "Launch at least one side project to a small public audience before graduating.",
+            "Land a software engineering role at a product company that allows remote work."
+        ],
+        "occupation": {
+            "title": "Computer Science Graduate Student",
+            "organization": "Ohio State University — part-time teaching assistant, personal side projects",
+            "description": "You are finishing your master's degree and working as a part-time TA on a limited monthly income. You discovered FlowDesk six months ago and use it to manage thesis milestones and a small side project. You compare paid tools against free or student-friendly alternatives, and you are willing to migrate if a tool no longer feels worth the subscription. Student pricing and transparent value matter to you, but you also appreciate software that genuinely saves time."
+        },
+        "style": "Casual and candid. You speak plainly, get to the point quickly, and are not interested in corporate-speak from vendors. You share opinions in online communities and are comfortable voicing criticism publicly.",
+        "personality": {
+            "traits": [
+                "Frugal — every recurring subscription competes with food, rent, and student loan interest.",
+                "Tech-savvy and comfortable evaluating and switching productivity tools quickly.",
+                "Curious about new tools but not emotionally attached to ones already in use.",
+                "Openly frustrated by companies that do not offer student or low-income pricing tiers.",
+                "Principled about not paying for things that have free, open-source, or community-supported alternatives."
+            ],
+            "big_five": {
+                "openness": "High. Enjoys exploring new tools, ideas, and technical approaches.",
+                "conscientiousness": "Medium. Disciplined on thesis work; looser on routine personal tasks.",
+                "extraversion": "Low-Medium. Active in online communities but prefers working alone.",
+                "agreeableness": "Medium. Friendly and collaborative but blunt when expressing dissatisfaction.",
+                "neuroticism": "Medium. Financial stress is real and persistent; unexpected expenses cause visible anxiety."
+            }
+        },
+        "preferences": {
+            "interests": [
+                "Open-source software, self-hosted tools, and free developer infrastructure.",
+                "Developer productivity, personal knowledge management, and note-taking systems.",
+                "Side projects, indie hacking, and building in public on social platforms.",
+                "Staying on free or student tiers of software wherever possible.",
+                "Distributed systems, backend engineering, and cloud-native architecture."
+            ],
+            "likes": [
+                "Free tiers that are genuinely usable, not crippled to force upgrades.",
+                "Student pricing programs that are easy to verify and apply.",
+                "Open-source alternatives to commercial productivity tools."
+            ],
+            "dislikes": [
+                "Companies that raise prices without acknowledging student or low-income users.",
+                "Freemium bait-and-switch — generous free tier until the company needs growth.",
+                "Being treated the same as an enterprise customer in vendor pricing decisions."
+            ]
+        },
+        "skills": [
+            "Proficient in Python, Go, and distributed systems concepts.",
+            "Experienced in evaluating and migrating between productivity and project management tools.",
+            "Comfortable with self-hosted alternatives to commercial SaaS products.",
+            "Active contributor to open-source repositories; familiar with GitHub, GitLab, and community tools."
+        ],
+        "beliefs": [
+            "Student pricing is an important signal that a vendor understands low-income users.",
+            "Even modest monthly fees are meaningful on a student budget.",
+            "Switching tools is a feature, not a bug; being locked in to a vendor is a liability.",
+            "The best tools for students are either free, open-source, or have transparent student pricing."
+        ],
+        "behaviors": {
+            "general": [
+                "Searches for a free or open-source alternative before considering any paid tool.",
+                "Cancels subscriptions promptly when they stop delivering clear, unique value.",
+                "Shares tool reviews and pricing opinions in Discord servers and Reddit communities."
+            ],
+            "routines": {
+                "morning": [
+                    "Checks GitHub notifications and any open pull requests on side projects.",
+                    "Reviews thesis milestone tasks in FlowDesk before starting work."
+                ],
+                "workday": [
+                    "Works on thesis research or TA grading in focused blocks.",
+                    "Spends 30-60 minutes on side project code in the afternoon.",
+                    "Reads Hacker News and tech newsletters between work blocks."
+                ],
+                "evening": [
+                    "Joins online communities to discuss tools, projects, and career questions.",
+                    "Tracks monthly expenses in a simple spreadsheet to manage his $1,200 budget."
+                ]
+            }
+        },
+        "health": "Generally healthy. Gets insufficient sleep during thesis crunch periods. Manages stress through late-night coding sessions, which is not always helpful.",
+        "relationships": [
+            {
+                "name": "Professor Alvarez",
+                "description": "Your thesis advisor. Demanding but supportive; expects regular milestone updates."
+            },
+            {
+                "name": "Dev Discord community",
+                "description": "An online community of 3,000+ early-career developers and students where you share tools, job tips, and opinions on SaaS pricing."
+            }
+        ],
+        "other_facts": [
+            "Uses a combination of Notion (free tier), GitHub Projects (free), and a plain markdown wiki for most of his personal organization needs.",
+            "Has written two blog posts critical of SaaS companies that removed free tiers; both were shared on Hacker News.",
+            "Keeps an eye on free individual plans from developer-focused tools, including Linear and GitHub Projects."
+        ]
+    }
+}

--- a/examples/agents/MayaChen.agent.json
+++ b/examples/agents/MayaChen.agent.json
@@ -1,0 +1,107 @@
+{
+    "type": "TinyPerson",
+    "persona": {
+        "name": "Maya Chen",
+        "age": 27,
+        "gender": "Female",
+        "nationality": "American",
+        "residence": "Oakland, CA, USA",
+        "education": "BFA in Graphic Design, California College of the Arts. Self-taught in UX research and interaction design through online courses and freelance projects.",
+        "long_term_goals": [
+            "Build a sustainable independent UX consultancy with a stable roster of retainer clients.",
+            "Achieve location independence and financial security on a freelance income.",
+            "Keep monthly fixed expenses low enough to weather slow client months without stress."
+        ],
+        "occupation": {
+            "title": "Freelance UX Designer",
+            "organization": "Self-employed",
+            "description": "You work independently on contract projects for small startups and digital agencies. Income is variable — good months bring in $4,000–$5,000, slow months much less. You review recurring subscriptions carefully and expect each tool to justify its cost. You use FlowDesk daily to track client tasks and log billable hours. You know free or cheaper alternatives like Notion, Trello, and Toggl exist, but you also weigh migration effort, client continuity, and whether the current tool is saving billable time."
+        },
+        "style": "Direct and no-nonsense. You communicate efficiently, dislike upselling, and appreciate vendors who are transparent about pricing and value.",
+        "personality": {
+            "traits": [
+                "Highly cost-conscious and deliberate with spending.",
+                "Pragmatic — you choose tools based on ROI, not brand loyalty.",
+                "Independent-minded and comfortable switching tools when a better option exists.",
+                "Values simplicity and dislikes feature bloat.",
+                "Skeptical of poorly explained SaaS pricing changes, especially when added features do not match your workflow."
+            ],
+            "big_five": {
+                "openness": "Medium. Open to new tools but only if they demonstrably improve your workflow.",
+                "conscientiousness": "High. Meticulous about tracking expenses and project time.",
+                "extraversion": "Low-Medium. Comfortable working alone for long stretches.",
+                "agreeableness": "Medium. Polite but firm; will push back on bad deals.",
+                "neuroticism": "Medium. Financial variability causes real stress; unexpected expenses amplify it."
+            }
+        },
+        "preferences": {
+            "interests": [
+                "Freelance community forums and productivity hacks.",
+                "Personal finance, budgeting, and financial independence.",
+                "Minimal, focused software tools with transparent pricing.",
+                "Remote work culture and async-first workflows.",
+                "Design systems and component-based UI work."
+            ],
+            "likes": [
+                "Annual billing options that offer a meaningful discount.",
+                "Tools that respect your time and wallet.",
+                "Transparent pricing pages with no hidden tiers."
+            ],
+            "dislikes": [
+                "Surprise price increases with short notice.",
+                "Feature bloat added to justify higher prices.",
+                "Vendor lock-in through proprietary data formats."
+            ]
+        },
+        "skills": [
+            "Proficient in Figma, Sketch, and Adobe XD for UI/UX design.",
+            "Experienced in user research, usability testing, and journey mapping.",
+            "Comfortable evaluating and migrating between productivity tools quickly.",
+            "Strong grasp of personal finance and subscription cost management."
+        ],
+        "beliefs": [
+            "SaaS companies often raise prices to fund features the core users never asked for.",
+            "Large price increases need a clear value explanation and enough notice.",
+            "Loyalty to a tool matters less than whether it is the best value for money right now.",
+            "Free or low-cost alternatives deserve serious evaluation before accepting any price increase."
+        ],
+        "behaviors": {
+            "general": [
+                "Reviews all recurring subscriptions monthly and cancels anything not earning its keep.",
+                "When software pricing changes, compares the new value against alternatives and migration effort.",
+                "Keeps a personal spreadsheet of all SaaS tools and their costs."
+            ],
+            "routines": {
+                "morning": [
+                    "Checks email and Slack messages from clients.",
+                    "Reviews the day's billable tasks in FlowDesk before starting work."
+                ],
+                "workday": [
+                    "Works in focused 90-minute blocks on client deliverables.",
+                    "Logs time in FlowDesk after each block.",
+                    "Responds to client messages in batched windows, not continuously."
+                ],
+                "evening": [
+                    "Reviews daily hours logged and invoices any completed milestones.",
+                    "Checks personal finance dashboard to monitor monthly burn rate."
+                ]
+            }
+        },
+        "health": "Generally healthy. Experiences occasional eye strain from long screen hours. Manages stress through running and cooking.",
+        "relationships": [
+            {
+                "name": "Jamie",
+                "description": "A fellow freelancer and close friend who shares tips on tools, clients, and financial management."
+            },
+            {
+                "name": "Priya",
+                "description": "A long-term retainer client at a Series A startup who provides steady, predictable monthly income."
+            }
+        ],
+        "other_facts": [
+            "Moved from New York to Oakland two years ago specifically to reduce her cost of living and extend her financial runway.",
+            "Has migrated between project management tools before when a better-fit option justified the effort.",
+            "Actively participates in a freelancers' Discord server where tool pricing changes are frequently discussed and criticized."
+        ]
+    }
+}

--- a/examples/agents/RajPatel.agent.json
+++ b/examples/agents/RajPatel.agent.json
@@ -1,0 +1,106 @@
+{
+    "type": "TinyPerson",
+    "persona": {
+        "name": "Raj Patel",
+        "age": 34,
+        "gender": "Male",
+        "nationality": "Indian-American",
+        "residence": "Austin, TX, USA",
+        "education": "BS in Computer Science, UT Austin. MBA from McCombs School of Business, focused on entrepreneurship and technology strategy.",
+        "long_term_goals": [
+            "Grow Nexify to a Series A funding round within 18 months.",
+            "Build a product-led growth motion that reduces reliance on outbound sales.",
+            "Keep monthly burn rate predictable enough to extend the current 14-month runway."
+        ],
+        "occupation": {
+            "title": "Co-founder and CEO",
+            "organization": "Nexify — early-stage B2B SaaS startup, 6 people, pre-Series A",
+            "description": "You run a small startup and are responsible for every operational decision. Your team of 6 relies on FlowDesk for sprint planning, task assignment, and weekly standups. You are on a tight runway — roughly 14 months of capital left — and scrutinize every tool subscription, but the switching cost of migrating six people to a new tool, losing historical data, and retraining the team is real. You evaluate changes in total team cost alongside product value, reliability, and disruption. You often look for annual terms, startup programs, or vendor conversations before making a tool decision."
+        },
+        "style": "Decisive and direct. You communicate with urgency but remain open to negotiation. You expect vendors to treat early-stage customers as partners, not just billing lines.",
+        "personality": {
+            "traits": [
+                "Resourceful and decisive under uncertainty.",
+                "Team-first — tool decisions affect everyone, not just yourself.",
+                "Comfortable negotiating with vendors for better pricing or annual deals.",
+                "Thinks in terms of burn rate and ROI rather than absolute price tags.",
+                "Loyal to tools that have supported the team through early growth, but not unconditionally."
+            ],
+            "big_five": {
+                "openness": "High. Constantly evaluating new approaches and tools for competitive advantage.",
+                "conscientiousness": "High. Tracks expenses, runway, and team productivity closely.",
+                "extraversion": "Medium-High. Energetic in pitches and team settings; quieter in solo work.",
+                "agreeableness": "Medium. Collaborative but willing to push back hard on unfavorable terms.",
+                "neuroticism": "Low-Medium. Manages startup stress well but feels real pressure around the runway."
+            }
+        },
+        "preferences": {
+            "interests": [
+                "Startup operations, lean team management, and unit economics.",
+                "Product management, OKR frameworks, and growth strategy.",
+                "Venture funding dynamics, term sheets, and bootstrapping philosophies.",
+                "Team productivity tools and async communication practices.",
+                "B2B SaaS pricing models and customer success strategies."
+            ],
+            "likes": [
+                "Vendors who offer startup pricing or acknowledge early-stage constraints.",
+                "Annual billing options with a meaningful discount over monthly.",
+                "Tools that improve team output visibly and measurably."
+            ],
+            "dislikes": [
+                "Vendors who treat small teams the same as enterprise customers.",
+                "Price increases applied without any discussion or grandfathering option.",
+                "Feature additions that do not serve the team's actual workflow."
+            ]
+        },
+        "skills": [
+            "Experienced in product roadmap planning, sprint execution, and cross-functional team coordination.",
+            "Proficient in financial modeling, burn rate analysis, and fundraising preparation.",
+            "Skilled at vendor negotiation and SaaS contract evaluation.",
+            "Comfortable evaluating tool switching costs across data migration, retraining time, and workflow disruption."
+        ],
+        "beliefs": [
+            "The switching cost of moving a whole team off a tool is often higher than a price increase.",
+            "A SaaS raising prices is acceptable if the product is genuinely improving and the communication is respectful.",
+            "Negotiating an annual plan is always worth attempting before accepting a monthly price increase.",
+            "Vendors who acknowledge startup constraints build longer-term loyalty than those who do not."
+        ],
+        "behaviors": {
+            "general": [
+                "Reviews the company's SaaS spend every month as part of burn rate management.",
+                "When vendor pricing changes, the first response is usually to ask about annual plan options or startup discounts.",
+                "Factors team disruption cost explicitly into any tool switching decision."
+            ],
+            "routines": {
+                "morning": [
+                    "Reviews overnight Slack messages and checks the sprint board in FlowDesk.",
+                    "Runs a 15-minute standup with the team to unblock dependencies."
+                ],
+                "workday": [
+                    "Splits time between product reviews, investor conversations, and operational decisions.",
+                    "Uses FlowDesk to assign tasks and track milestone progress across the team."
+                ],
+                "evening": [
+                    "Reviews daily spend and burn metrics.",
+                    "Catches up on founder newsletters and investor updates."
+                ]
+            }
+        },
+        "health": "Good health overall. Manages mild stress through weekend cycling. Tends to skip meals during high-pressure weeks.",
+        "relationships": [
+            {
+                "name": "Ananya",
+                "description": "Your co-founder and CTO. Makes the final call on technical tool choices; you align with her on team workflow decisions."
+            },
+            {
+                "name": "Marcus",
+                "description": "Your lead investor and board advisor. Monitors burn rate closely and expects monthly financial updates."
+            }
+        ],
+        "other_facts": [
+            "Has been a paying FlowDesk customer since the company's first week — it is one of the few tools the whole team has adopted without friction.",
+            "Has negotiated annual deals with two other SaaS vendors in the past 12 months, saving a combined $1,200 per year.",
+            "Is actively building a competitor analysis matrix to evaluate alternatives to every critical tool in the stack, as part of pre-Series A cost optimization."
+        ]
+    }
+}

--- a/examples/agents/SarahKim.agent.json
+++ b/examples/agents/SarahKim.agent.json
@@ -1,0 +1,106 @@
+{
+    "type": "TinyPerson",
+    "persona": {
+        "name": "Sarah Kim",
+        "age": 41,
+        "gender": "Female",
+        "nationality": "Korean-American",
+        "residence": "Chicago, IL, USA",
+        "education": "BA in Economics, Northwestern University. MBA from Kellogg School of Management, specializing in strategy and operations.",
+        "long_term_goals": [
+            "Move into a VP of Product role at a large financial services or fintech company within three years.",
+            "Develop a reputation as a product leader who bridges technical depth and business strategy.",
+            "Build a strong network of cross-functional peers in enterprise software and financial services."
+        ],
+        "occupation": {
+            "title": "Senior Product Manager",
+            "organization": "Meridian Financial — Fortune 500 financial services company, approximately 8,000 employees",
+            "description": "You manage a product portfolio at a large financial services company. You use FlowDesk personally for your own task management — it is one of roughly a dozen tools in your workflow. Individual productivity subscriptions are usually manageable for you, but you care strongly about vendor communication, transparency, and advance notice. You evaluate even personal tools through a procurement lens and would think differently if a pricing change affected an enterprise-wide subscription."
+        },
+        "style": "Measured, analytical, and direct. You evaluate vendor decisions through a procurement lens even for personal tools. You expect professional communication and fair dealing from software companies.",
+        "personality": {
+            "traits": [
+                "Confident and direct in vendor interactions.",
+                "Holds strong standards for vendor communication, transparency, and fair dealing.",
+                "High personal switching cost — deeply integrated with enterprise tool ecosystem.",
+                "Pragmatic about cost at the individual level, but principled about policy and fairness.",
+                "Evaluates business decisions systematically rather than reacting emotionally."
+            ],
+            "big_five": {
+                "openness": "Medium-High. Open to new processes and frameworks; more conservative on tool changes.",
+                "conscientiousness": "Very High. Rigorous, organized, and thorough in all professional work.",
+                "extraversion": "Medium. Comfortable in leadership settings; values focused independent work.",
+                "agreeableness": "Medium. Collaborative and respectful but will hold firm on matters of principle.",
+                "neuroticism": "Low. Calm under pressure; responds to frustration with structured critique rather than reaction."
+            }
+        },
+        "preferences": {
+            "interests": [
+                "Enterprise software ecosystems, vendor management, and procurement strategy.",
+                "Product strategy, roadmap planning, and executive stakeholder alignment.",
+                "Organizational process design and operational excellence.",
+                "Leadership communication, influence without authority, and executive presence.",
+                "Financial services technology trends and regulatory compliance."
+            ],
+            "likes": [
+                "Vendors who communicate pricing changes with ample notice and a clear rationale.",
+                "Grandfathering options or transition discounts for existing customers.",
+                "Enterprise-grade reliability and support responsiveness."
+            ],
+            "dislikes": [
+                "Price increases framed as improvements when the improvements are not requested.",
+                "Short notice periods that do not allow for budget planning.",
+                "Vendors who do not differentiate between individual and enterprise pricing tiers."
+            ]
+        },
+        "skills": [
+            "Experienced in product lifecycle management, OKR setting, and cross-functional roadmap execution.",
+            "Skilled at stakeholder communication, executive presentations, and business case development.",
+            "Proficient in vendor evaluation, contract review, and enterprise procurement processes.",
+            "Strong analytical skills in data-driven product decision-making and A/B testing frameworks."
+        ],
+        "beliefs": [
+            "Price increases without adequate notice or grandfathering are a signal of poor vendor culture.",
+            "For personal productivity tools, the exact dollar amount is often less important to you than the principle, precedent, and communication quality.",
+            "Software vendors should differentiate their pricing and communication for individual versus enterprise customers.",
+            "A company that raises prices aggressively without consultation tends to repeat the behavior."
+        ],
+        "behaviors": {
+            "general": [
+                "Reviews vendor communications carefully and evaluates them against enterprise procurement standards, even for personal tools.",
+                "When annoyed by a vendor decision, writes a measured and specific response rather than simply canceling.",
+                "Keeps notes on vendor behavior as input for future procurement recommendations."
+            ],
+            "routines": {
+                "morning": [
+                    "Reviews calendar, flags high-priority stakeholder messages, and updates her task list in FlowDesk.",
+                    "Prepares for any cross-functional meetings with a written agenda."
+                ],
+                "workday": [
+                    "Runs product reviews, writes specifications, and manages stakeholder alignment across engineering, design, and compliance.",
+                    "Uses FlowDesk to track personal deliverables and follow-up actions from meetings."
+                ],
+                "evening": [
+                    "Reads product management and fintech news.",
+                    "Reviews and updates her weekly priorities for the next day."
+                ]
+            }
+        },
+        "health": "Good health. Manages work stress through yoga and weekend hiking. Occasional tension headaches during high-stakes delivery cycles.",
+        "relationships": [
+            {
+                "name": "David",
+                "description": "Your VP of Product and direct manager. Supportive but expects clean, data-backed recommendations."
+            },
+            {
+                "name": "Mei",
+                "description": "Your peer in IT procurement. You consult her whenever a personal tool has enterprise adoption potential."
+            }
+        ],
+        "other_facts": [
+            "Has been responsible for evaluating and recommending enterprise software tools at two previous companies; applies the same rigor to personal tools.",
+            "Once led a vendor audit that resulted in a 35% reduction in SaaS spend across a 200-person product organization.",
+            "Writes occasional LinkedIn posts on product leadership; has 12,000 followers in the product management community."
+        ]
+    }
+}

--- a/tests/scenarios/test_pricing_simulation_scenarios.py
+++ b/tests/scenarios/test_pricing_simulation_scenarios.py
@@ -1,0 +1,235 @@
+"""
+Scenario tests for the pricing change customer response simulation.
+
+These tests verify that four customer personas — spanning different income levels,
+usage intensities, and switching costs — produce structurally valid and behaviorally
+distinct responses to a SaaS price increase.
+
+Per TinyTroupe contribution guidelines, all LLM calls use real API calls (no mocking).
+Use --use_cache to run from cached responses and avoid API costs on repeated runs.
+"""
+import json
+import logging
+import os
+
+import pytest
+
+logger = logging.getLogger("tinytroupe")
+
+import sys
+
+sys.path.insert(0, "../../tinytroupe/")
+sys.path.insert(0, "../../")
+sys.path.insert(0, "..")
+
+import tinytroupe
+from tinytroupe.agent import TinyPerson
+from tinytroupe.environment import TinyWorld
+from tinytroupe.extraction import ResultsExtractor
+import tinytroupe.control as control
+
+from testing_utils import *
+
+# Path to the persona JSON files shared with the notebook example
+_AGENTS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "examples", "agents")
+
+
+def _agent_path(filename):
+    return os.path.join(_AGENTS_DIR, filename)
+
+
+# ── Shared scenario content ────────────────────────────────────────────────────
+# These constants are identical to those in the notebook so the test exercises
+# exactly the same scenario.
+
+PRODUCT_CONTEXT = (
+    "You are a paying customer of FlowDesk, a productivity SaaS tool you have been using "
+    "for the past year. FlowDesk helps you manage tasks, track time, and collaborate on "
+    "projects. You currently pay $12/month and have integrated it into your daily workflow."
+)
+
+PRICING_ANNOUNCEMENT = (
+    "You just received this email from FlowDesk:\n\n"
+    "Subject: Important update to your FlowDesk subscription\n\n"
+    "Hi there,\n\n"
+    "We are writing to let you know that starting next billing cycle, your FlowDesk "
+    "monthly subscription will increase from $12/month to $18/month. This change reflects "
+    "our ongoing investment in new collaboration features, a redesigned mobile app, and "
+    "faster customer support.\n\n"
+    "Your account, data, and current plan features remain unchanged. If you have "
+    "questions, our support team is here to help.\n\n"
+    "Thank you for being a FlowDesk customer.\n"
+    "— The FlowDesk Team\n\n"
+    "How do you feel about this? What will you do?"
+)
+
+REFLECTION_PRIMER = (
+    "I will think carefully and honestly about this situation. I will consider: "
+    "how much I actually use and value FlowDesk, how $6/month more fits into my budget, "
+    "whether I trust this company and its communication, whether I would look for "
+    "alternatives, and what specific improvements I would need to see to feel the "
+    "price increase is justified. I will not give a polite or generic answer "
+    "— I will respond as I genuinely would in real life."
+)
+
+# Fields extracted in both tests — kept intentionally concise for cost efficiency
+_EXTRACTION_FIELDS = ["name", "switching_risk", "overall_reaction"]
+_EXTRACTION_HINTS = {
+    "switching_risk": "One of: Very High, High, Medium, Low, Very Low.",
+    "overall_reaction": "One of: Strongly Positive, Positive, Neutral, Negative, Strongly Negative.",
+}
+
+# Full field list used by the structural completeness test
+REQUIRED_FIELDS = [
+    "name",
+    "switching_risk",
+    "likelihood_to_continue",
+    "likelihood_to_churn",
+    "likelihood_to_recommend",
+    "requested_improvements",
+    "overall_reaction",
+]
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.slow
+def test_pricing_simulation_produces_structured_results(setup):
+    """
+    Full end-to-end simulation: four personas receive the pricing announcement and
+    ResultsExtractor returns a dict with all required fields for each agent.
+
+    Personas are loaded from the same JSON files used by the notebook, ensuring
+    the test exercises the exact same persona definitions the user sees.
+    """
+    control.reset()
+
+    maya  = TinyPerson.load_specification(_agent_path("MayaChen.agent.json"))
+    raj   = TinyPerson.load_specification(_agent_path("RajPatel.agent.json"))
+    sarah = TinyPerson.load_specification(_agent_path("SarahKim.agent.json"))
+    ethan = TinyPerson.load_specification(_agent_path("EthanBrooks.agent.json"))
+
+    world = TinyWorld(
+        "FlowDesk Customer Panel",
+        [maya, raj, sarah, ethan],
+        broadcast_if_no_target=False,
+    )
+
+    world.broadcast(PRODUCT_CONTEXT)
+    world.broadcast(PRICING_ANNOUNCEMENT)
+    world.broadcast_thought(REFLECTION_PRIMER)
+    world.run(1)
+
+    extractor = ResultsExtractor(
+        extraction_objective=(
+            "Determine how the customer persona responded to a 50% price increase "
+            "($12/month to $18/month) for a productivity SaaS called FlowDesk."
+        ),
+        situation=(
+            "The agent received an email announcing a price increase from $12 to $18/month "
+            "and was asked to respond honestly and in character."
+        ),
+        fields=REQUIRED_FIELDS,
+        fields_hints={
+            "switching_risk": "One of: Very High, High, Medium, Low, Very Low.",
+            "likelihood_to_continue": "Integer 1-5. 1 = will definitely cancel, 5 = will definitely stay. Or N/A.",
+            "likelihood_to_churn": "Integer 1-5. 1 = will definitely stay, 5 = will definitely cancel. Or N/A.",
+            "likelihood_to_recommend": "Integer 1-5. 1 = would never recommend, 5 = would strongly recommend. Or N/A.",
+            "requested_improvements": "Comma-separated list of requested changes. Write 'None mentioned' if none.",
+            "overall_reaction": "One of: Strongly Positive, Positive, Neutral, Negative, Strongly Negative.",
+        },
+        verbose=False,
+    )
+
+    results = extractor.extract_results_from_agents(world.agents)
+    valid_results = [r for r in results if isinstance(r, dict)]
+
+    # All four agents should produce a result
+    assert len(valid_results) == 4, (
+        f"Expected 4 extracted results, got {len(valid_results)}. "
+        f"Raw results: {results}"
+    )
+
+    # Each result must contain all required fields
+    for result in valid_results:
+        for field in REQUIRED_FIELDS:
+            assert field in result, (
+                f"Field '{field}' missing from result for {result.get('name', '?')}. "
+                f"Got keys: {list(result.keys())}"
+            )
+
+
+@pytest.mark.slow
+def test_pricing_simulation_churn_variance(setup):
+    """
+    Verify that the simulation produces meaningful variance in churn signals across personas.
+
+    Maya (budget freelancer) and Ethan (grad student) are expected to show higher churn
+    intent than Sarah (enterprise PM), who has low price sensitivity and high switching cost.
+    This tests that personas with different financial constraints produce differentiated
+    behavioral outputs — the core value proposition of persona-based simulation.
+
+    Assertions use proposition_holds() on short extracted result strings (not raw interaction
+    histories), consistent with how other scenario tests in this suite validate outcomes.
+    """
+    control.reset()
+
+    maya  = TinyPerson.load_specification(_agent_path("MayaChen.agent.json"))
+    sarah = TinyPerson.load_specification(_agent_path("SarahKim.agent.json"))
+    ethan = TinyPerson.load_specification(_agent_path("EthanBrooks.agent.json"))
+
+    world = TinyWorld(
+        "FlowDesk Churn Contrast",
+        [maya, sarah, ethan],
+        broadcast_if_no_target=False,
+    )
+
+    world.broadcast(PRODUCT_CONTEXT)
+    world.broadcast(PRICING_ANNOUNCEMENT)
+    world.broadcast_thought(REFLECTION_PRIMER)
+    world.run(1)
+
+    # Extract a concise result for each agent — used as the proposition context
+    extractor = ResultsExtractor(
+        extraction_objective=(
+            "Determine whether the customer persona intends to stay with or leave FlowDesk "
+            "after a 50% price increase, and how strongly they reacted."
+        ),
+        situation=(
+            "The agent received a price increase announcement from $12 to $18/month "
+            "and was asked to respond in character."
+        ),
+        fields=_EXTRACTION_FIELDS,
+        fields_hints=_EXTRACTION_HINTS,
+        verbose=False,
+    )
+
+    results = extractor.extract_results_from_agents(world.agents)
+    by_name = {r["name"]: r for r in results if isinstance(r, dict) and "name" in r}
+
+    maya_result  = json.dumps(by_name.get("Maya Chen", {}))
+    sarah_result = json.dumps(by_name.get("Sarah Kim", {}))
+    ethan_result = json.dumps(by_name.get("Ethan Brooks", {}))
+
+    # Maya — budget freelancer — should show high switching risk or negative reaction
+    assert proposition_holds(
+        f"The following data describes Maya Chen's reaction to a 50% SaaS price increase: "
+        f"{maya_result}. "
+        f"The data indicates concern, frustration, high switching risk, or a negative reaction."
+    ), f"Maya (budget freelancer) should show high churn intent. Got: {maya_result}"
+
+    # Ethan — grad student — should show very high switching risk or strongly negative reaction
+    assert proposition_holds(
+        f"The following data describes Ethan Brooks's reaction to a 50% SaaS price increase: "
+        f"{ethan_result}. "
+        f"The data indicates that $18/month is too expensive or that the persona would "
+        f"switch to a free or cheaper alternative."
+    ), f"Ethan (grad student) should show very high churn intent. Got: {ethan_result}"
+
+    # Sarah — enterprise PM — should show low switching risk despite possible disapproval
+    assert proposition_holds(
+        f"The following data describes Sarah Kim's reaction to a 50% SaaS price increase: "
+        f"{sarah_result}. "
+        f"The data indicates low or medium switching risk — the persona is unlikely to cancel "
+        f"immediately, even if she disapproves of how the increase was communicated."
+    ), f"Sarah (enterprise PM) should show low switching risk. Got: {sarah_result}"


### PR DESCRIPTION
## Summary
Adds a TinyTroupe notebook demonstrating how to simulate customer reactions to a SaaS pricing change using four reusable personas, `TinyWorld.broadcast()`, and `ResultsExtractor`.

## Value
This expands the examples with a pricing/churn research scenario, which is distinct from the existing product/ad market research examples. It shows how segment differences such as budget pressure, switching cost, team dependency, and vendor trust can influence simulated customer responses.

## Safety and hygiene
- No API keys or credentials are committed.
- Notebook outputs and execution counts are cleared.
- `openai_api_cache.json` is ignored to avoid committing API cache artifacts.
- Persona validation is opt-in because it makes additional API calls.

## Validation
- Parsed notebook and agent JSON successfully.
- Python syntax check passed for the new scenario test.
- Whitespace check passed with `git diff --cached --check`.
- Full pytest execution should be run in CI or a fully installed TinyTroupe environment.