### PR TITLE
fix: resolve invalid escape sequence warning in llm.py

### DIFF
--- a/tinytroupe/utils/llm.py
+++ b/tinytroupe/utils/llm.py
@@ -956,7 +956,7 @@ class LLMChat:
     def _request_list_of_dict_llm_message(self):
         return {
             "role": "user",
-            "content": "The `value` field you generate **must** be a list of dictionaries, specified as a JSON structure embedded in a string. For example, `[\{...\}, \{...\}, ...]`. This is critical for later processing.",
+            "content": "The `value` field you generate **must** be a list of dictionaries, specified as a JSON structure embedded in a string. For example, `[\\{...\\}, \\{...\\}, ...]`. This is critical for later processing.",
         }
 
     def _coerce_to_list(self, llm_output: str):


### PR DESCRIPTION
## 🐛 Bug Fix: Invalid Escape Sequence Warning

**Problem**: Python SyntaxWarning for invalid escape sequence '\{' in string literal (line 959)

**Solution**: Fixed escape sequence from  to  for proper string formatting

**Impact**: 
- ✅ Resolves Python compilation warning
- ✅ Improves code quality
- ✅ No functional changes, only syntax correction

**Testing**: Verified with 

---

## Context
This PR extracts a single, focused fix from the larger refactoring effort to address the now-closed PR #153. Rather than a massive 25K+ line PR, this provides a minimal, reviewable fix for immediate improvement.

**Files Changed**: 1 file, 1 insertion(+), 1 deletion(-)

**Review Priority**: LOW - Minor syntax warning fix