### PR TITLE
feat: enhance JSON extraction with markdown block support

### DIFF
--- a/tinytroupe/utils/llm.py
+++ b/tinytroupe/utils/llm.py
@@ -1132,13 +1132,20 @@ def extract_json(text: str) -> dict:
 
         filtered_text = ""
 
-        # remove any text before the first opening curly or square braces, using regex. Leave the braces.
-        filtered_text = re.sub(r"^.*?({|\[)", r"\1", text, flags=re.DOTALL)
+        # Strategy 1: Try to extract JSON from markdown code blocks first
+        json_block_match = re.search(r'```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```', text, re.DOTALL)
+        if json_block_match:
+            filtered_text = json_block_match.group(1)
+            logger.debug("Extracted JSON from markdown code block")
+        else:
+            # Strategy 2: Fallback to original extraction method
+            # remove any text before the first opening curly or square braces, using regex. Leave the braces.
+            filtered_text = re.sub(r"^.*?({|\[)", r"\1", text, flags=re.DOTALL)
 
-        # remove any trailing text after the LAST closing curly or square braces, using regex. Leave the braces.
-        filtered_text = re.sub(
-            r"(}|\])(?!.*(\]|\})).*$", r"\1", filtered_text, flags=re.DOTALL
-        )
+            # remove any trailing text after the LAST closing curly or square braces, using regex. Leave the braces.
+            filtered_text = re.sub(
+                r"(}|\])(?!.*(\]|\})).*$", r"\1", filtered_text, flags=re.DOTALL
+            )
 
         # remove invalid escape sequences, which show up sometimes
         # Handle common problematic escape sequences more comprehensively


### PR DESCRIPTION
Enhanced JSON extraction from LLM responses with markdown code block support

Improvement:
- Added priority extraction for JSON in markdown code blocks (both json and plain tags)
- Maintains backward compatibility with existing JSON formats
- Better handling of structured data from conversational LLM responses

Benefits:
- Improved parsing of LLM responses wrapped in markdown
- More robust extraction of structured data
- Maintains all existing functionality

Testing:
- Standard JSON: PASS
- Markdown blocks with json tag: PASS  
- Markdown blocks without tag: PASS
- Embedded JSON in text: PASS

Files: 1 file changed (+13, -6)
Impact: Enhanced reliability for JSON extraction from LLM responses