### PR TITLE
Feat/add litellm provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "scipy"
 ]
 
+[project.optional-dependencies]
+litellm = ["litellm>=1.83.0,<2.0"]
+
 [project.urls]
 "Homepage" = "https://github.com/microsoft/tinytroupe"
 

--- a/tests/unit/test_litellm_client.py
+++ b/tests/unit/test_litellm_client.py
@@ -1,0 +1,377 @@
+import json
+import sys
+import types
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+sys.path.insert(0, "..")
+sys.path.insert(0, "../../")
+
+
+def _make_mock_response(content="Test response", role="assistant", finish_reason="stop"):
+    """Build a mock litellm.ModelResponse-like object."""
+    response = MagicMock()
+    response.model_dump.return_value = {
+        "choices": [
+            {
+                "message": {"role": role, "content": content},
+                "finish_reason": finish_reason,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+    return response
+
+
+def _make_empty_response():
+    """Build a response with null content."""
+    response = MagicMock()
+    response.model_dump.return_value = {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": None},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    return response
+
+
+def _make_malformed_response():
+    """Build a response with missing choices."""
+    response = MagicMock()
+    response.model_dump.return_value = {"choices": []}
+    return response
+
+
+class TestLiteLLMClient:
+
+    @pytest.mark.core
+    def test_basic_completion(self):
+        """Test that a normal completion call dispatches correctly and returns parsed content."""
+        import litellm
+        with patch.object(litellm, "completion", return_value=_make_mock_response("Hello!")) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "Say hello"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=1,
+                waiting_time=0,
+            )
+            assert result is not None
+            assert result["content"] == "Hello!"
+            assert result["role"] == "assistant"
+            mock_comp.assert_called_once()
+            call_kwargs = mock_comp.call_args[1]
+            assert call_kwargs["model"] == "openai/gpt-4o-mini"
+            assert call_kwargs["stream"] is False
+
+    @pytest.mark.core
+    def test_drop_params_default_true(self):
+        """Verify drop_params=True is always sent by default."""
+        import litellm
+        with patch.object(litellm, "completion", return_value=_make_mock_response()) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="anthropic/claude-haiku-4-5",
+                max_attempts=1,
+                waiting_time=0,
+            )
+            call_kwargs = mock_comp.call_args[1]
+            assert call_kwargs.get("drop_params") is True
+
+    @pytest.mark.core
+    def test_auth_error_no_retry(self):
+        """AuthenticationError should NOT trigger retry - fail immediately."""
+        import litellm
+        with patch.object(
+            litellm, "completion",
+            side_effect=litellm.AuthenticationError(
+                message="Invalid API key", model="test", llm_provider="openai"
+            ),
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=3,
+                waiting_time=0,
+            )
+            assert result is None
+            assert mock_comp.call_count == 1
+
+    @pytest.mark.core
+    def test_bad_request_no_retry(self):
+        """BadRequestError should NOT trigger retry."""
+        import litellm
+        with patch.object(
+            litellm, "completion",
+            side_effect=litellm.BadRequestError(
+                message="Invalid model", model="test", llm_provider="openai"
+            ),
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="nonexistent/model",
+                max_attempts=3,
+                waiting_time=0,
+            )
+            assert result is None
+            assert mock_comp.call_count == 1
+
+    @pytest.mark.core
+    def test_model_not_found_no_retry(self):
+        """NotFoundError should NOT trigger retry."""
+        import litellm
+        with patch.object(
+            litellm, "completion",
+            side_effect=litellm.NotFoundError(
+                message="Model not found", model="test", llm_provider="openai"
+            ),
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/nonexistent-model",
+                max_attempts=3,
+                waiting_time=0,
+            )
+            assert result is None
+            assert mock_comp.call_count == 1
+
+    @pytest.mark.core
+    def test_rate_limit_retries(self):
+        """RateLimitError should trigger retry with backoff."""
+        import litellm
+        rate_err = litellm.RateLimitError(
+            message="Rate limit", model="test", llm_provider="openai"
+        )
+        with patch.object(
+            litellm, "completion",
+            side_effect=[rate_err, _make_mock_response("recovered")],
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=3,
+                waiting_time=0,
+            )
+            assert result is not None
+            assert result["content"] == "recovered"
+            assert mock_comp.call_count == 2
+
+    @pytest.mark.core
+    def test_timeout_retries(self):
+        """Timeout should trigger retry."""
+        import litellm
+        timeout_err = litellm.Timeout(
+            message="Request timed out", model="test", llm_provider="openai"
+        )
+        with patch.object(
+            litellm, "completion",
+            side_effect=[timeout_err, _make_mock_response("ok")],
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=3,
+                waiting_time=0,
+            )
+            assert result is not None
+            assert mock_comp.call_count == 2
+
+    @pytest.mark.core
+    def test_empty_response_retries(self):
+        """Empty/null response content should trigger retry."""
+        import litellm
+        with patch.object(
+            litellm, "completion",
+            side_effect=[_make_empty_response(), _make_mock_response("valid")],
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=3,
+                waiting_time=0,
+            )
+            assert result is not None
+            assert result["content"] == "valid"
+            assert mock_comp.call_count == 2
+
+    @pytest.mark.core
+    def test_malformed_response_returns_none(self):
+        """Malformed response (empty choices) should not crash."""
+        import litellm
+        with patch.object(
+            litellm, "completion",
+            return_value=_make_malformed_response(),
+        ):
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=1,
+                waiting_time=0,
+            )
+            assert result is None
+
+    @pytest.mark.core
+    def test_all_retries_exhausted(self):
+        """When all retries fail, should return None."""
+        import litellm
+        with patch.object(
+            litellm, "completion",
+            side_effect=litellm.APIConnectionError(
+                message="Connection refused", model="test", llm_provider="openai"
+            ),
+        ) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            result = client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=2,
+                waiting_time=0,
+            )
+            assert result is None
+            assert mock_comp.call_count == 2
+
+    @pytest.mark.core
+    def test_messages_forwarded_correctly(self):
+        """Verify messages list is passed through to litellm.completion."""
+        import litellm
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "Hello"},
+        ]
+        with patch.object(litellm, "completion", return_value=_make_mock_response()) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            client.send_message(
+                messages,
+                model="openai/gpt-4o-mini",
+                max_attempts=1,
+                waiting_time=0,
+                dedent_messages=False,
+            )
+            call_kwargs = mock_comp.call_args[1]
+            assert call_kwargs["messages"] == messages
+
+    @pytest.mark.core
+    def test_none_params_stripped(self):
+        """Verify None-valued params are excluded from the API call."""
+        import litellm
+        with patch.object(litellm, "completion", return_value=_make_mock_response()) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            client.send_message(
+                [{"role": "user", "content": "test"}],
+                model="openai/gpt-4o-mini",
+                temperature=None,
+                top_p=None,
+                frequency_penalty=None,
+                presence_penalty=None,
+                max_attempts=1,
+                waiting_time=0,
+            )
+            call_kwargs = mock_comp.call_args[1]
+            assert "temperature" not in call_kwargs
+            assert "top_p" not in call_kwargs
+            assert "frequency_penalty" not in call_kwargs
+            assert "presence_penalty" not in call_kwargs
+
+    @pytest.mark.core
+    def test_token_counter(self):
+        """Verify token counting delegates to litellm."""
+        import litellm
+        with patch.object(litellm, "token_counter", return_value=42) as mock_tc:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            count = client._count_tokens(
+                [{"role": "user", "content": "hello"}],
+                "openai/gpt-4o-mini",
+            )
+            assert count == 42
+            mock_tc.assert_called_once()
+
+    @pytest.mark.core
+    def test_import_error_message(self):
+        """Verify clear error when litellm not installed."""
+        import importlib
+        from tinytroupe.clients import litellm_client
+
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "litellm":
+                raise ImportError("No module named 'litellm'")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            importlib.reload(litellm_client)
+            client = litellm_client.LiteLLMClient()
+            with pytest.raises(ImportError, match="pip install"):
+                client.send_message(
+                    [{"role": "user", "content": "test"}],
+                    model="openai/gpt-4o-mini",
+                    max_attempts=1,
+                    waiting_time=0,
+                )
+
+        importlib.reload(litellm_client)
+
+    @pytest.mark.core
+    def test_client_registered_in_registry(self):
+        """Verify litellm client is registered and retrievable."""
+        from tinytroupe.clients import _get_client_for_api_type
+        client = _get_client_for_api_type("litellm")
+        assert client.__class__.__name__ == "LiteLLMClient"
+
+    @pytest.mark.core
+    def test_caching_stores_and_retrieves(self):
+        """Verify response caching works."""
+        import litellm
+        mock_resp = _make_mock_response("cached answer")
+        with patch.object(litellm, "completion", return_value=mock_resp) as mock_comp:
+            from tinytroupe.clients.litellm_client import LiteLLMClient
+            client = LiteLLMClient()
+            client.cache_api_calls = True
+            client.api_cache = {}
+            client.cache_file_name = "/dev/null"
+
+            result1 = client.send_message(
+                [{"role": "user", "content": "cache test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=1,
+                waiting_time=0,
+                dedent_messages=False,
+            )
+            result2 = client.send_message(
+                [{"role": "user", "content": "cache test"}],
+                model="openai/gpt-4o-mini",
+                max_attempts=1,
+                waiting_time=0,
+                dedent_messages=False,
+            )
+            assert result1["content"] == "cached answer"
+            assert result2["content"] == "cached answer"
+            assert mock_comp.call_count == 1

--- a/tinytroupe/clients/__init__.py
+++ b/tinytroupe/clients/__init__.py
@@ -3,6 +3,7 @@ import logging
 from tinytroupe import config_manager, utils
 
 from .azure_client import AzureClient
+from .litellm_client import LiteLLMClient
 from .ollama_client import OllamaClient
 from .openai_client import LLMCacheBase, OpenAIClient
 
@@ -118,3 +119,4 @@ def force_api_cache(cache_api_calls, cache_file_name=None):
 register_client("openai", OpenAIClient())
 register_client("azure", AzureClient())
 register_client("ollama", OllamaClient())
+register_client("litellm", LiteLLMClient())

--- a/tinytroupe/clients/litellm_client.py
+++ b/tinytroupe/clients/litellm_client.py
@@ -7,6 +7,17 @@ from tinytroupe.clients.openai_client import LLMCacheBase
 logger = logging.getLogger("tinytroupe")
 
 
+def _import_litellm():
+    try:
+        import litellm
+        return litellm
+    except ImportError:
+        raise ImportError(
+            "litellm is required for the LiteLLM client. "
+            "Install it with: pip install 'tinytroupe[litellm]'"
+        )
+
+
 class LiteLLMClient(LLMCacheBase):
     """
     A client for interacting with LLM providers through LiteLLM,
@@ -58,19 +69,22 @@ class LiteLLMClient(LLMCacheBase):
         Sends a message via LiteLLM and returns the response.
         Follows the same interface as OpenAIClient.send_message.
         """
-        import litellm
+        litellm = _import_litellm()
 
         from tinytroupe.clients import InvalidRequestError, NonTerminalError
 
         def aux_exponential_backoff():
             nonlocal waiting_time
-            if waiting_time <= 0:
+            if waiting_time is None or waiting_time <= 0:
                 waiting_time = 2
             logger.info(
                 f"Request failed. Waiting {waiting_time} seconds between requests..."
             )
             time.sleep(waiting_time)
-            waiting_time = waiting_time * exponential_backoff_factor
+            waiting_time = waiting_time * (exponential_backoff_factor or 5)
+
+        if max_attempts is None:
+            max_attempts = 2
 
         if dedent_messages:
             for message in current_messages:
@@ -106,11 +120,11 @@ class LiteLLMClient(LLMCacheBase):
                 logger.debug(f"Sending request via LiteLLM. Attempt {i}")
 
                 cache_key = str((model, chat_api_params))
-                if self.cache_api_calls and (cache_key in self.api_cache):
+                if self.cache_api_calls and hasattr(self, 'api_cache') and (cache_key in self.api_cache):
                     response = self.api_cache[cache_key]
                     raw_message = self._extract_response(response)
                 else:
-                    if waiting_time > 0:
+                    if waiting_time is not None and waiting_time > 0:
                         logger.info(
                             f"Waiting {waiting_time} seconds before next API request..."
                         )
@@ -120,6 +134,8 @@ class LiteLLMClient(LLMCacheBase):
                     response_dict = response.model_dump()
 
                     if self.cache_api_calls:
+                        if not hasattr(self, 'api_cache'):
+                            self.api_cache = {}
                         self.api_cache[cache_key] = response_dict
                         self._save_cache()
 
@@ -129,6 +145,11 @@ class LiteLLMClient(LLMCacheBase):
                 logger.debug(
                     f"Got response in {end_time - start_time:.2f} seconds after {i} attempts."
                 )
+
+                if raw_message is None or raw_message.get("content") is None:
+                    logger.warning("LiteLLM returned empty response content")
+                    aux_exponential_backoff()
+                    continue
 
                 return utils.sanitize_dict(raw_message)
 
@@ -144,6 +165,10 @@ class LiteLLMClient(LLMCacheBase):
                 logger.error(f"[{i}] Authentication error, won't retry: {e}")
                 return None
 
+            except litellm.NotFoundError as e:
+                logger.error(f"[{i}] Model not found, won't retry: {e}")
+                return None
+
             except litellm.RateLimitError:
                 logger.warning(
                     f"[{i}] Rate limit error, waiting a bit and trying again."
@@ -152,13 +177,26 @@ class LiteLLMClient(LLMCacheBase):
 
             except litellm.Timeout as e:
                 logger.error(f"[{i}] Timeout error: {e}")
+                aux_exponential_backoff()
+
+            except litellm.APIConnectionError as e:
+                logger.error(f"[{i}] API connection error: {e}")
+                aux_exponential_backoff()
+
+            except litellm.InternalServerError as e:
+                logger.error(f"[{i}] Provider internal server error: {e}")
+                aux_exponential_backoff()
+
+            except litellm.ServiceUnavailableError as e:
+                logger.error(f"[{i}] Service unavailable: {e}")
+                aux_exponential_backoff()
 
             except NonTerminalError as e:
                 logger.error(f"[{i}] Non-terminal error: {e}")
                 aux_exponential_backoff()
 
             except Exception as e:
-                logger.error(f"[{i}] {type(e).__name__} Error: {e}")
+                logger.error(f"[{i}] Unexpected {type(e).__name__}: {e}")
                 aux_exponential_backoff()
 
         logger.error(f"Failed to get response after {max_attempts} attempts.")
@@ -169,21 +207,27 @@ class LiteLLMClient(LLMCacheBase):
         Extracts the relevant information from the API response dict.
         """
         try:
+            choice = response["choices"][0]
+            message = choice.get("message", {})
             return {
-                "role": response["choices"][0]["message"]["role"],
-                "content": response["choices"][0]["message"]["content"],
+                "role": message.get("role", "assistant"),
+                "content": message.get("content"),
             }
-        except (KeyError, IndexError) as e:
+        except (KeyError, IndexError, TypeError) as e:
             logger.error(f"Error extracting response: {e}")
-            raise ValueError("Invalid response format from LiteLLM")
+            logger.error(f"Response structure: {response}")
+            return None
 
     def _count_tokens(self, messages: list, model: str):
         """
         Count tokens using LiteLLM's token counter.
         """
         try:
-            import litellm
+            litellm = _import_litellm()
             return litellm.token_counter(model=model, messages=messages)
+        except ImportError:
+            logger.debug("litellm not installed, skipping token count")
+            return None
         except Exception as e:
             logger.error(f"Error counting tokens: {e}")
             return None

--- a/tinytroupe/clients/litellm_client.py
+++ b/tinytroupe/clients/litellm_client.py
@@ -1,0 +1,189 @@
+import logging
+import time
+
+from tinytroupe import config_manager, utils
+from tinytroupe.clients.openai_client import LLMCacheBase
+
+logger = logging.getLogger("tinytroupe")
+
+
+class LiteLLMClient(LLMCacheBase):
+    """
+    A client for interacting with LLM providers through LiteLLM,
+    providing unified access to 100+ LLM providers (OpenAI, Anthropic,
+    Google, Azure, Bedrock, Ollama, and more) via a single interface.
+    """
+
+    @config_manager.config_defaults(
+        cache_api_calls="cache_api_calls", cache_file_name="cache_file_name"
+    )
+    def __init__(self, cache_api_calls=None, cache_file_name=None) -> None:
+        logger.debug("Initializing LiteLLMClient")
+        self.set_api_cache(cache_api_calls, cache_file_name)
+
+    @config_manager.config_defaults(
+        model="model",
+        temperature="temperature",
+        max_completion_tokens="max_completion_tokens",
+        frequency_penalty="frequency_penalty",
+        presence_penalty="presence_penalty",
+        timeout="timeout",
+        max_attempts="max_attempts",
+        waiting_time="waiting_time",
+        exponential_backoff_factor="exponential_backoff_factor",
+        response_format=None,
+        echo=None,
+    )
+    def send_message(
+        self,
+        current_messages,
+        dedent_messages=True,
+        model=None,
+        temperature=None,
+        max_completion_tokens=None,
+        top_p=None,
+        frequency_penalty=None,
+        presence_penalty=None,
+        stop=None,
+        timeout=None,
+        max_attempts=None,
+        waiting_time=None,
+        exponential_backoff_factor=None,
+        n=1,
+        response_format=None,
+        enable_pydantic_model_return=False,
+        echo=False,
+    ):
+        """
+        Sends a message via LiteLLM and returns the response.
+        Follows the same interface as OpenAIClient.send_message.
+        """
+        import litellm
+
+        from tinytroupe.clients import InvalidRequestError, NonTerminalError
+
+        def aux_exponential_backoff():
+            nonlocal waiting_time
+            if waiting_time <= 0:
+                waiting_time = 2
+            logger.info(
+                f"Request failed. Waiting {waiting_time} seconds between requests..."
+            )
+            time.sleep(waiting_time)
+            waiting_time = waiting_time * exponential_backoff_factor
+
+        if dedent_messages:
+            for message in current_messages:
+                if "content" in message and isinstance(message["content"], str):
+                    message["content"] = utils.dedent(message["content"])
+
+        chat_api_params = {
+            "model": model,
+            "messages": current_messages,
+            "temperature": temperature,
+            "max_completion_tokens": max_completion_tokens,
+            "top_p": top_p,
+            "frequency_penalty": frequency_penalty,
+            "presence_penalty": presence_penalty,
+            "stop": stop,
+            "timeout": timeout,
+            "stream": False,
+            "n": n,
+            "drop_params": True,
+        }
+
+        if response_format is not None:
+            chat_api_params["response_format"] = response_format
+
+        chat_api_params = {k: v for k, v in chat_api_params.items() if v is not None}
+
+        i = 0
+        while i < max_attempts:
+            try:
+                i += 1
+
+                start_time = time.monotonic()
+                logger.debug(f"Sending request via LiteLLM. Attempt {i}")
+
+                cache_key = str((model, chat_api_params))
+                if self.cache_api_calls and (cache_key in self.api_cache):
+                    response = self.api_cache[cache_key]
+                    raw_message = self._extract_response(response)
+                else:
+                    if waiting_time > 0:
+                        logger.info(
+                            f"Waiting {waiting_time} seconds before next API request..."
+                        )
+                        time.sleep(waiting_time)
+
+                    response = litellm.completion(**chat_api_params)
+                    response_dict = response.model_dump()
+
+                    if self.cache_api_calls:
+                        self.api_cache[cache_key] = response_dict
+                        self._save_cache()
+
+                    raw_message = self._extract_response(response_dict)
+
+                end_time = time.monotonic()
+                logger.debug(
+                    f"Got response in {end_time - start_time:.2f} seconds after {i} attempts."
+                )
+
+                return utils.sanitize_dict(raw_message)
+
+            except InvalidRequestError as e:
+                logger.error(f"[{i}] Invalid request error, won't retry: {e}")
+                return None
+
+            except litellm.BadRequestError as e:
+                logger.error(f"[{i}] Bad request error, won't retry: {e}")
+                return None
+
+            except litellm.AuthenticationError as e:
+                logger.error(f"[{i}] Authentication error, won't retry: {e}")
+                return None
+
+            except litellm.RateLimitError:
+                logger.warning(
+                    f"[{i}] Rate limit error, waiting a bit and trying again."
+                )
+                aux_exponential_backoff()
+
+            except litellm.Timeout as e:
+                logger.error(f"[{i}] Timeout error: {e}")
+
+            except NonTerminalError as e:
+                logger.error(f"[{i}] Non-terminal error: {e}")
+                aux_exponential_backoff()
+
+            except Exception as e:
+                logger.error(f"[{i}] {type(e).__name__} Error: {e}")
+                aux_exponential_backoff()
+
+        logger.error(f"Failed to get response after {max_attempts} attempts.")
+        return None
+
+    def _extract_response(self, response):
+        """
+        Extracts the relevant information from the API response dict.
+        """
+        try:
+            return {
+                "role": response["choices"][0]["message"]["role"],
+                "content": response["choices"][0]["message"]["content"],
+            }
+        except (KeyError, IndexError) as e:
+            logger.error(f"Error extracting response: {e}")
+            raise ValueError("Invalid response format from LiteLLM")
+
+    def _count_tokens(self, messages: list, model: str):
+        """
+        Count tokens using LiteLLM's token counter.
+        """
+        try:
+            import litellm
+            return litellm.token_counter(model=model, messages=messages)
+        except Exception as e:
+            logger.error(f"Error counting tokens: {e}")
+            return None


### PR DESCRIPTION
## Summary

Add a **LiteLLM** client that gives TinyTroupe unified access to 100+ LLM providers (Anthropic, Google, Azure, Bedrock, Groq, Ollama, and more) through a single `API_TYPE=litellm` config option.


Each new provider currently needs its own client class. LiteLLM eliminates that by providing a single interface to 100+ providers.

## Changes

- `tinytroupe/clients/litellm_client.py` - New `LiteLLMClient` extending `LLMCacheBase`
- `tinytroupe/clients/__init__.py` - Registered as `register_client("litellm", LiteLLMClient())`
- `pyproject.toml` - Added `litellm>=1.83.0,<2.0` as optional dependency
- `tests/unit/test_litellm_client.py` - 16 unit tests

## Implementation details

- Same `send_message()` interface as `OpenAIClient` - all parameters forwarded identically
- `drop_params=True` by default so provider-unsupported kwargs (e.g. `frequency_penalty` on Anthropic) are silently dropped
- Specific exception handling: `AuthenticationError`, `BadRequestError`, `NotFoundError` fail immediately (no retry); `RateLimitError`, `Timeout`, `APIConnectionError`, `InternalServerError`, `ServiceUnavailableError` retry with exponential backoff
- Empty/null response content triggers retry instead of returning garbage
- `litellm` lazy-imported inside method bodies so the module loads without it installed
- Clear `ImportError` message with install instructions when litellm is missing
- Token counting via `litellm.token_counter()` with graceful fallback
- JSON cache inherited from `LLMCacheBase`

## Tests

**16 unit tests covering:**
- Basic completion dispatch + response parsing
- `drop_params=True` always present
- Auth error, bad request, model not found - no retry (1 API call each)
- Rate limit, timeout - retries with backoff (2 calls, then succeeds)
- Empty/null response - retries
- Malformed response (empty choices) - returns None gracefully
- All retries exhausted - returns None
- Messages forwarded correctly to `litellm.completion()`
- None-valued params excluded from API call
- Token counter delegation to `litellm.token_counter()`
- Import error message includes `pip install` instruction
- Client registered and retrievable from registry
- Response caching (second call hits cache, not API)

**Live E2E (Anthropic via Azure Foundry):**
```
>>> client.send_message([{'role': 'user', 'content': 'What is 2+2? Reply with just the number.'}],
...     model='anthropic/claude-sonnet-4-6', max_attempts=1, waiting_time=0)
LiteLLM completion() model= claude-sonnet-4-6; provider = anthropic
Wrapper: Completed Call, calling success_handler
Result: {'role': 'assistant', 'content': '4'}
```

## Example usage


```python
import os
os.environ["ANTHROPIC_API_KEY"] = "sk-ant-..."

# LiteLLM reads provider keys from env automatically
# Model format: provider/model-name
# Examples: openai/gpt-5-mini, gemini/gemini-2.5-flash, ollama/llama3

from tinytroupe.clients import client, force_api_type
force_api_type("litellm")

response = client().send_message(
    [{"role": "user", "content": "What is quantum entanglement?"}],
    model="anthropic/claude-sonnet-4-6",
    temperature=0.7,
)
print(response["content"])
```

```bash
pip install -e ".[litellm]"
```

## Risk / Compatibility

- Additive only - existing OpenAI, Azure, and Ollama clients untouched
- `litellm` is an optional extra - base install unaffected
- No changes to core simulation logic
