### PR TITLE
Reject malformed JSON in LLM coercion

### DIFF
--- a/tests/unit/test_llm_chat.py
+++ b/tests/unit/test_llm_chat.py
@@ -408,6 +408,11 @@ class TestLLMChat:
         result = chat._coerce_to_dict_or_list(json_array)
         assert result == [{"name": "John"}, {"name": "Jane"}]
 
+        # Valid empty JSON object with whitespace
+        empty_json_object = "  { }\n"
+        result = chat._coerce_to_dict_or_list(empty_json_object)
+        assert result == {}
+
         # Already a dict
         dict_input = {"key": "value"}
         result = chat._coerce_to_dict_or_list(dict_input)
@@ -427,6 +432,15 @@ class TestLLMChat:
 
         with pytest.raises(ValueError, match="Cannot convert"):
             chat._coerce_to_dict_or_list("42")  # valid JSON but not dict/list
+
+        for malformed_json in (
+            "[{[}]",
+            "{not json}",
+            'prefix {"name": } suffix',
+            "malformed {[}] followed by {}",
+        ):
+            with pytest.raises(ValueError, match="Cannot convert"):
+                chat._coerce_to_dict_or_list(malformed_json)
 
     def test_coerce_to_list_valid_inputs(self):
         """Test list coercion with valid inputs."""

--- a/tinytroupe/utils/llm.py
+++ b/tinytroupe/utils/llm.py
@@ -933,7 +933,7 @@ class LLMChat:
             # extract_json returns {} on failure, but we need dict or list
             if result == {} and not (
                 isinstance(llm_output, str)
-                and ("{}" in llm_output or "{" in llm_output and "}" in llm_output)
+                and re.fullmatch(r"\s*\{\s*\}\s*", llm_output)
             ):
                 raise ValueError(
                     "Cannot convert the LLM output to a dict or list value."


### PR DESCRIPTION
## Summary

- accept an empty JSON object only when the complete LLM output is `{}` (allowing surrounding/interior whitespace)
- reject malformed or mixed JSON that `extract_json` reports with its `{}` failure sentinel
- add regression coverage for the reported mismatched-brace response and related malformed outputs

## Validation

- `pytest tests/unit/test_llm_chat.py -k coerce_to_dict_or_list -q` — 2 passed
- `pytest tests/unit/test_llm_chat.py -k coerce -q` — 12 passed
- `pytest tests/unit/test_utils.py -k 'extract_json or name_or_empty or repeat_on_error' -q` — 3 passed\n- `black --check tests/unit/test_llm_chat.py --target-version py310`\n- `python -m py_compile tinytroupe/utils/llm.py tests/unit/test_llm_chat.py`\n- `git diff --check`\n\nFixes #159