### PR TITLE
Fixes and enhancements to TinyCalendar tool

### DIFF
--- a/tests/unit/test_tiny_calendar.py
+++ b/tests/unit/test_tiny_calendar.py
@@ -1,0 +1,529 @@
+import pytest
+import logging
+logger = logging.getLogger("tinytroupe")
+
+import sys
+sys.path.insert(0, '../../tinytroupe/')
+sys.path.insert(0, '../../')
+sys.path.insert(0, '..')
+
+from tinytroupe.tools import TinyCalendar
+from tinytroupe.examples import create_oscar_the_architect, create_lisa_the_data_scientist
+from testing_utils import *
+
+
+def test_calendar_initialization(setup):
+    """Test TinyCalendar initialization."""
+    calendar = TinyCalendar()
+    assert calendar.name == "calendar"
+    assert calendar.description is not None
+    assert calendar.owner is None
+    assert calendar.real_world_side_effects == False
+    assert calendar.calendar == {}
+
+
+def test_calendar_add_event(setup):
+    """Test adding events directly via add_event()."""
+    calendar = TinyCalendar()
+
+    # Add an event on a specific date
+    calendar.add_event(
+        date="2025-03-15",
+        title="Team meeting",
+        description="Weekly sync",
+        owner="Oscar",
+        mandatory_attendees=["Oscar", "Lisa"],
+        optional_attendees=["Marcos"],
+        start_time="10:00",
+        end_time="11:00"
+    )
+
+    assert "2025-03-15" in calendar.calendar
+    assert len(calendar.calendar["2025-03-15"]) == 1
+
+    event = calendar.calendar["2025-03-15"][0]
+    assert event["title"] == "Team meeting"
+    assert event["description"] == "Weekly sync"
+    assert event["owner"] == "Oscar"
+    assert event["mandatory_attendees"] == ["Oscar", "Lisa"]
+    assert event["optional_attendees"] == ["Marcos"]
+    assert event["start_time"] == "10:00"
+    assert event["end_time"] == "11:00"
+
+
+def test_calendar_add_multiple_events_same_date(setup):
+    """Test adding multiple events on the same date."""
+    calendar = TinyCalendar()
+
+    calendar.add_event("2025-03-15", "Morning standup", start_time="09:00")
+    calendar.add_event("2025-03-15", "Lunch break", start_time="12:00")
+    calendar.add_event("2025-03-15", "Afternoon review", start_time="15:00")
+
+    assert len(calendar.calendar["2025-03-15"]) == 3
+
+
+def test_calendar_add_events_different_dates(setup):
+    """Test adding events on different dates."""
+    calendar = TinyCalendar()
+
+    calendar.add_event("2025-03-15", "Event on 15th")
+    calendar.add_event("2025-03-16", "Event on 16th")
+    calendar.add_event("2025-03-17", "Event on 17th")
+
+    assert len(calendar.calendar) == 3
+    assert len(calendar.calendar["2025-03-15"]) == 1
+    assert len(calendar.calendar["2025-03-16"]) == 1
+    assert len(calendar.calendar["2025-03-17"]) == 1
+
+
+def test_process_action_creates_event(setup):
+    """Test that _process_action handles a valid CREATE_EVENT action."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "CREATE_EVENT",
+        "content": '{"date": "2025-06-01", "title": "Project kickoff", "description": "Initial meeting", "start_time": "09:00", "end_time": "10:30"}'
+    }
+
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+    assert "2025-06-01" in calendar.calendar
+    event = calendar.calendar["2025-06-01"][0]
+    assert event["title"] == "Project kickoff"
+    assert event["start_time"] == "09:00"
+    assert event["end_time"] == "10:30"
+
+
+def test_process_action_with_owner(setup):
+    """Test CREATE_EVENT with owner field."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "CREATE_EVENT",
+        "content": '{"date": "2025-06-01", "title": "Design review", "owner": "Oscar"}'
+    }
+
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+    event = calendar.calendar["2025-06-01"][0]
+    assert event["owner"] == "Oscar"
+
+
+def test_process_action_with_attendees(setup):
+    """Test CREATE_EVENT with attendee lists."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "CREATE_EVENT",
+        "content": '{"date": "2025-06-01", "title": "Team sync", "mandatory_attendees": ["Oscar", "Lisa"], "optional_attendees": ["Marcos"]}'
+    }
+
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+    event = calendar.calendar["2025-06-01"][0]
+    assert event["mandatory_attendees"] == ["Oscar", "Lisa"]
+    assert event["optional_attendees"] == ["Marcos"]
+
+
+def test_process_action_invalid_field(setup):
+    """Test CREATE_EVENT with an invalid field raises ValueError."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "CREATE_EVENT",
+        "content": '{"date": "2025-06-01", "title": "Bad event", "invalid_field": "should fail"}'
+    }
+
+    with pytest.raises(ValueError, match="Invalid key"):
+        calendar._process_action(agent, action)
+
+
+def test_process_action_missing_content(setup):
+    """Test CREATE_EVENT with None content returns False."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {"type": "CREATE_EVENT", "content": None}
+
+    result = calendar._process_action(agent, action)
+    assert result == False
+
+
+def test_process_action_wrong_type(setup):
+    """Test non-CREATE_EVENT action returns False."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {"type": "TALK", "content": "Hello"}
+    result = calendar._process_action(agent, action)
+    assert result == False
+
+
+def test_find_events_by_date(setup):
+    """Test find_events returns events for a specific date."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "Independence day BBQ")
+    calendar.add_event("2025-07-04", "Fireworks show", start_time="21:00")
+    calendar.add_event("2025-07-05", "Recovery brunch")
+
+    events = calendar.find_events(2025, 7, 4)
+    assert len(events) == 2
+
+
+def test_find_events_no_match(setup):
+    """Test find_events returns empty list when no events exist."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "Some event")
+
+    events = calendar.find_events(2025, 12, 25)
+    assert len(events) == 0
+
+
+def test_find_events_with_hour_filter(setup):
+    """Test find_events with hour filtering."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "Morning", start_time="09:00")
+    calendar.add_event("2025-07-04", "Afternoon", start_time="14:00")
+    calendar.add_event("2025-07-04", "Evening", start_time="18:00")
+
+    events = calendar.find_events(2025, 7, 4, hour=14)
+    assert len(events) == 1
+    assert events[0]["title"] == "Afternoon"
+
+
+def test_find_events_with_hour_and_minute_filter(setup):
+    """Test find_events with hour and minute filtering."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "Standup", start_time="09:00")
+    calendar.add_event("2025-07-04", "Detail meeting", start_time="09:30")
+    calendar.add_event("2025-07-04", "Workshop", start_time="10:00")
+
+    events = calendar.find_events(2025, 7, 4, hour=9, minute=30)
+    assert len(events) == 1
+    assert events[0]["title"] == "Detail meeting"
+
+
+def test_find_events_events_without_time(setup):
+    """Test find_events with time filter includes events without start_time."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "All-day event", start_time=None)
+    calendar.add_event("2025-07-04", "Timed event", start_time="10:00")
+
+    # Time filter should include events without a start time
+    events = calendar.find_events(2025, 7, 4, hour=10)
+    assert len(events) == 2
+
+
+def test_actions_definitions_prompt(setup):
+    """Test actions_definitions_prompt returns a non-empty string mentioning CREATE_EVENT."""
+    calendar = TinyCalendar()
+    prompt = calendar.actions_definitions_prompt()
+    assert len(prompt) > 0
+    assert "CREATE_EVENT" in prompt
+
+
+def test_actions_constraints_prompt(setup):
+    """Test actions_constraints_prompt returns a non-empty string."""
+    calendar = TinyCalendar()
+    prompt = calendar.actions_constraints_prompt()
+    assert len(prompt) > 0
+    assert "CREATE_EVENT" in prompt
+
+
+def test_calendar_ownership(setup):
+    """Test TinyCalendar inherits ownership enforcement from TinyTool."""
+    oscar = create_oscar_the_architect()
+    lisa = create_lisa_the_data_scientist()
+
+    calendar = TinyCalendar(owner=oscar)
+
+    # Oscar can use the calendar
+    action = {
+        "type": "CREATE_EVENT",
+        "content": '{"date": "2025-06-01", "title": "Oscar\'s event"}'
+    }
+    result = calendar.process_action(oscar, action)
+    assert result == True
+
+    # Lisa should not be able to use Oscar's calendar
+    with pytest.raises(ValueError, match="does not own"):
+        calendar.process_action(lisa, action)
+
+
+def test_calendar_serializable_attributes(setup):
+    """Test that TinyCalendar includes calendar state in serializable attributes."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-08-01", "Test event")
+    assert "calendar" in calendar.serializable_attributes
+
+    calendar.add_event("2025-08-01", "Another event")
+    assert len(calendar.calendar["2025-08-01"]) == 2
+
+
+def test_calendar_serialization_to_json(setup):
+    """Test that TinyCalendar can serialize/deserialize its state via to_json / from_json."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-08-01", "Test event", start_time="10:00")
+    calendar.add_event("2025-08-01", "Another event", start_time="14:00")
+    calendar.add_event("2025-09-15", "Future event")
+
+    serialized = calendar.to_json()
+
+    # Check that calendar data was serialized
+    assert "calendar" in serialized
+    assert "2025-08-01" in serialized["calendar"]
+    assert len(serialized["calendar"]["2025-08-01"]) == 2
+    assert serialized["calendar"]["2025-08-01"][0]["title"] == "Test event"
+    assert serialized["calendar"]["2025-08-01"][1]["start_time"] == "14:00"
+    assert serialized["calendar"]["2025-09-15"][0]["title"] == "Future event"
+
+    # Deserialize into a new calendar
+    calendar2 = TinyCalendar.from_json(serialized)
+
+    # Check that events were restored
+    assert "2025-08-01" in calendar2.calendar
+    assert "2025-09-15" in calendar2.calendar
+    assert len(calendar2.calendar["2025-08-01"]) == 2
+    assert calendar2.calendar["2025-08-01"][0]["title"] == "Test event"
+
+
+# ===== New action types: FIND_EVENTS =====
+
+def test_process_action_find_events_found(setup):
+    """Test FIND_EVENTS returns events via agent.think()."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-07-04", "BBQ", start_time="12:00")
+    calendar.add_event("2025-07-04", "Fireworks", start_time="21:00")
+
+    action = {
+        "type": "FIND_EVENTS",
+        "content": '{"year": 2025, "month": 7, "day": 4}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True
+    # agent.think() was called — no crash means success
+
+
+def test_process_action_find_events_not_found(setup):
+    """Test FIND_EVENTS with no matching date."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-07-04", "BBQ")
+
+    action = {
+        "type": "FIND_EVENTS",
+        "content": '{"year": 2025, "month": 12, "day": 25}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+
+def test_process_action_find_events_with_hour(setup):
+    """Test FIND_EVENTS with hour filter."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-07-04", "Morning", start_time="09:00")
+    calendar.add_event("2025-07-04", "Afternoon", start_time="14:00")
+
+    action = {
+        "type": "FIND_EVENTS",
+        "content": '{"year": 2025, "month": 7, "day": 4, "hour": 14}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+
+def test_process_action_find_events_invalid_field(setup):
+    """Test FIND_EVENTS with invalid field raises ValueError."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "FIND_EVENTS",
+        "content": '{"year": 2025, "month": 7, "day": 4, "invalid": "bad"}'
+    }
+    with pytest.raises(ValueError, match="Invalid key"):
+        calendar._process_action(agent, action)
+
+
+# ===== New action types: LIST_EVENTS =====
+
+def test_process_action_list_events_with_data(setup):
+    """Test LIST_EVENTS returns events across dates."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-07-04", "BBQ")
+    calendar.add_event("2025-07-05", "Brunch")
+
+    action = {"type": "LIST_EVENTS"}
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+
+def test_process_action_list_events_empty(setup):
+    """Test LIST_EVENTS with no events."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {"type": "LIST_EVENTS"}
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+
+def test_process_action_list_events_with_max_results(setup):
+    """Test LIST_EVENTS with max_results filter."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-01-01", "Event 1")
+    calendar.add_event("2025-01-02", "Event 2")
+    calendar.add_event("2025-01-03", "Event 3")
+
+    action = {
+        "type": "LIST_EVENTS",
+        "content": '{"max_results": 2}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True
+
+
+# ===== New action types: DELETE_EVENT =====
+
+def test_process_action_delete_event_found(setup):
+    """Test DELETE_EVENT removes an event."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-07-04", "BBQ")
+
+    action = {
+        "type": "DELETE_EVENT",
+        "content": '{"date": "2025-07-04", "title": "BBQ"}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True
+    assert "2025-07-04" not in calendar.calendar  # date key cleaned up
+
+
+def test_process_action_delete_event_not_found(setup):
+    """Test DELETE_EVENT when event does not exist."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "DELETE_EVENT",
+        "content": '{"date": "2025-07-04", "title": "Nonexistent"}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True  # still returns True (action was valid), but think() reports failure
+
+
+def test_process_action_delete_event_with_start_time(setup):
+    """Test DELETE_EVENT with start_time disambiguation."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+    calendar.add_event("2025-07-04", "Meeting", start_time="09:00")
+    calendar.add_event("2025-07-04", "Meeting", start_time="14:00")
+
+    action = {
+        "type": "DELETE_EVENT",
+        "content": '{"date": "2025-07-04", "title": "Meeting", "start_time": "09:00"}'
+    }
+    result = calendar._process_action(agent, action)
+    assert result == True
+    assert len(calendar.calendar["2025-07-04"]) == 1
+    assert calendar.calendar["2025-07-04"][0]["start_time"] == "14:00"
+
+
+def test_process_action_delete_event_invalid_field(setup):
+    """Test DELETE_EVENT with invalid field raises ValueError."""
+    calendar = TinyCalendar()
+    agent = create_oscar_the_architect()
+
+    action = {
+        "type": "DELETE_EVENT",
+        "content": '{"date": "2025-07-04", "title": "X", "bad_field": "bad"}'
+    }
+    with pytest.raises(ValueError, match="Invalid key"):
+        calendar._process_action(agent, action)
+
+
+# ===== list_events() and delete_event() programmatic API =====
+
+def test_list_events_all(setup):
+    """Test list_events returns all events sorted chronologically."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-03-02", "Second")
+    calendar.add_event("2025-03-01", "First")
+    calendar.add_event("2025-03-03", "Third")
+
+    events = calendar.list_events()
+    assert len(events) == 3
+    assert events[0]["title"] == "First"
+    assert events[1]["title"] == "Second"
+    assert events[2]["title"] == "Third"
+
+
+def test_list_events_max_results(setup):
+    """Test list_events with max_results."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-03-01", "First")
+    calendar.add_event("2025-03-02", "Second")
+    calendar.add_event("2025-03-03", "Third")
+
+    events = calendar.list_events(max_results=2)
+    assert len(events) == 2
+    assert events[0]["title"] == "First"
+    assert events[1]["title"] == "Second"
+
+
+def test_list_events_empty(setup):
+    """Test list_events returns empty list when no events."""
+    calendar = TinyCalendar()
+    events = calendar.list_events()
+    assert events == []
+
+
+def test_delete_event_by_title(setup):
+    """Test delete_event removes by title."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "BBQ")
+    calendar.add_event("2025-07-04", "Cleanup")
+
+    result = calendar.delete_event("2025-07-04", "BBQ")
+    assert result == True
+    assert len(calendar.calendar["2025-07-04"]) == 1
+    assert calendar.calendar["2025-07-04"][0]["title"] == "Cleanup"
+
+
+def test_delete_event_not_found(setup):
+    """Test delete_event returns False when no match."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "BBQ")
+
+    result = calendar.delete_event("2025-07-04", "Nonexistent")
+    assert result == False
+    assert len(calendar.calendar["2025-07-04"]) == 1
+
+
+def test_delete_event_date_not_found(setup):
+    """Test delete_event returns False when date doesn't exist."""
+    calendar = TinyCalendar()
+
+    result = calendar.delete_event("2025-07-04", "BBQ")
+    assert result == False
+
+
+def test_delete_event_removes_empty_date(setup):
+    """Test delete_event cleans up empty date keys."""
+    calendar = TinyCalendar()
+    calendar.add_event("2025-07-04", "Only event")
+
+    calendar.delete_event("2025-07-04", "Only event")
+    assert "2025-07-04" not in calendar.calendar

--- a/tinytroupe/tools/tiny_calendar.py
+++ b/tinytroupe/tools/tiny_calendar.py
@@ -1,19 +1,21 @@
 
-import textwrap
 import json
+from datetime import datetime, timedelta
 
 from tinytroupe.tools import logger, TinyTool
 import tinytroupe.utils as utils
 
 
-# TODO under development
 class TinyCalendar(TinyTool):
+    serializable_attributes = ["name", "description", "real_world_side_effects", "calendar"]
 
-    def __init__(self, owner=None):
+    def __init__(self, owner=None, world=None):
         super().__init__("calendar", "A basic calendar tool that allows agents to keep track meetings and appointments.", owner=owner, real_world_side_effects=False)
         
         # maps date to list of events. Each event itself is a dictionary with keys "title", "description", "owner", "mandatory_attendees", "optional_attendees", "start_time", "end_time"
-        self.calenar = {}
+        self.calendar = {}
+        # optional reference to the TinyWorld for cross-agent notifications
+        self.world = world
     
     def add_event(self, date, title, description=None, owner=None, mandatory_attendees=None, optional_attendees=None, start_time=None, end_time=None):
         if date not in self.calendar:
@@ -21,21 +23,174 @@ class TinyCalendar(TinyTool):
         self.calendar[date].append({"title": title, "description": description, "owner": owner, "mandatory_attendees": mandatory_attendees, "optional_attendees": optional_attendees, "start_time": start_time, "end_time": end_time})
     
     def find_events(self, year, month, day, hour=None, minute=None):
-        # TODO
-        pass
+        """
+        Finds events for a given date. Optionally filters by hour and minute.
+        Returns a list of event dicts matching the criteria.
+        """
+        date_key = f"{year:04d}-{month:02d}-{day:02d}"
+        events_on_date = self.calendar.get(date_key, [])
+
+        if hour is None and minute is None:
+            return events_on_date
+
+        # Filter by time if specified
+        matched = []
+        for event in events_on_date:
+            start = event.get("start_time")
+            if start is None:
+                # Events without a start time match any time filter
+                matched.append(event)
+            else:
+                try:
+                    event_hour, event_minute = start.split(":")
+                    event_hour, event_minute = int(event_hour), int(event_minute)
+                    if event_hour == hour and (minute is None or event_minute == minute):
+                        matched.append(event)
+                except (ValueError, AttributeError):
+                    matched.append(event)
+        return matched
+    
+    def list_events(self, max_results=None):
+        """
+        Lists all events across all dates, sorted chronologically.
+        Returns a list of dicts, each with a "date" key plus the event data.
+        
+        Args:
+            max_results: Maximum number of events to return. None means all.
+        """
+        all_events = []
+        for date_key in sorted(self.calendar.keys()):
+            for event in self.calendar[date_key]:
+                entry = {"date": date_key, **event}
+                all_events.append(entry)
+        
+        if max_results is not None:
+            return all_events[:max_results]
+        return all_events
+    
+    def delete_event(self, date, title, start_time=None):
+        """
+        Deletes an event by date, title, and optionally start_time.
+        Returns True if an event was removed, False otherwise.
+        """
+        if date not in self.calendar:
+            return False
+        
+        original_count = len(self.calendar[date])
+        if start_time is not None:
+            self.calendar[date] = [
+                e for e in self.calendar[date]
+                if not (e["title"] == title and e["start_time"] == start_time)
+            ]
+        else:
+            self.calendar[date] = [
+                e for e in self.calendar[date]
+                if e["title"] != title
+            ]
+        
+        removed = original_count - len(self.calendar[date])
+        # Clean up empty date entries
+        if len(self.calendar[date]) == 0:
+            del self.calendar[date]
+        
+        return removed > 0
 
     def _process_action(self, agent, action) -> bool:
-        if action['type'] == "CREATE_EVENT" and action['content'] is not None:
+        action_type = action['type']
+        
+        if action_type == "CREATE_EVENT" and action.get('content') is not None:
             # parse content json
             event_content = json.loads(action['content'])
             
             # checks whether there are any kwargs that are not valid
-            valid_keys = ["title", "description", "mandatory_attendees", "optional_attendees", "start_time", "end_time"]
+            valid_keys = ["date", "title", "description", "owner", "mandatory_attendees", "optional_attendees", "start_time", "end_time"]
             utils.check_valid_fields(event_content, valid_keys)
 
             # uses the kwargs to create a new event
-            self.add_event(event_content)
+            self.add_event(**event_content)
 
+            # Notify attendees if a world reference is available
+            attendees = []
+            if event_content.get("mandatory_attendees"):
+                attendees.extend(event_content["mandatory_attendees"])
+            if event_content.get("optional_attendees"):
+                attendees.extend(event_content["optional_attendees"])
+            
+            if attendees and self.world is not None:
+                from tinytroupe.environment.tiny_world import TinyWorld
+                for attendee_name in attendees:
+                    attendee_agent = self.world.get_agent_by_name(attendee_name)
+                    if attendee_agent is not None:
+                        # Make agents mutually accessible for interaction
+                        attendee_agent.make_agent_accessible(agent)
+                        agent.make_agent_accessible(attendee_agent)
+                        # Social notification
+                        attendee_agent.socialize(
+                            f"You have been invited to the event '{event_content.get('title', 'Untitled')}' "
+                            f"on {event_content.get('date', 'unknown date')} "
+                            f"by {event_content.get('owner', agent.name)}.",
+                            source=agent
+                        )
+                    else:
+                        logger.warning(f"Attendee '{attendee_name}' not found in the world.")
+            
+            agent.think(f"I have created a new event '{event_content.get('title', 'Untitled')}' on {event_content.get('date', 'unknown date')} in my calendar.")
+
+            return True
+
+        elif action_type == "FIND_EVENTS" and action.get('content') is not None:
+            query = json.loads(action['content'])
+            valid_keys = ["year", "month", "day", "hour", "minute"]
+            utils.check_valid_fields(query, valid_keys)
+            
+            events = self.find_events(
+                year=query.get("year"),
+                month=query.get("month"),
+                day=query.get("day"),
+                hour=query.get("hour"),
+                minute=query.get("minute")
+            )
+            
+            if events:
+                summary = "; ".join([f"{e['title']} at {e.get('start_time', 'all day')}" for e in events])
+                agent.think(f"I found {len(events)} event(s) in my calendar on {query['year']}-{query['month']:02d}-{query['day']:02d}: {summary}.")
+            else:
+                agent.think(f"I found no events in my calendar on {query['year']}-{query['month']:02d}-{query['day']:02d}.")
+            
+            return True
+
+        elif action_type == "LIST_EVENTS":
+            max_results = None
+            if action.get('content') is not None:
+                params = json.loads(action['content'])
+                max_results = params.get("max_results", None)
+            
+            events = self.list_events(max_results=max_results)
+            
+            if events:
+                summary = "; ".join([f"[{e['date']}] {e['title']} at {e.get('start_time', 'all day')}" for e in events])
+                agent.think(f"I have {len(events)} upcoming event(s) in my calendar: {summary}.")
+            else:
+                agent.think("I have no events in my calendar.")
+            
+            return True
+
+        elif action_type == "DELETE_EVENT" and action.get('content') is not None:
+            query = json.loads(action['content'])
+            valid_keys = ["date", "title", "start_time"]
+            utils.check_valid_fields(query, valid_keys)
+            
+            removed = self.delete_event(
+                date=query.get("date"),
+                title=query.get("title"),
+                start_time=query.get("start_time")
+            )
+            
+            if removed:
+                agent.think(f"I have deleted the event '{query['title']}' from my calendar.")
+            else:
+                agent.think(f"I could not find an event '{query['title']}' on {query.get('date', 'any date')} in my calendar.")
+            
             return True
 
         else:
@@ -45,14 +200,29 @@ class TinyCalendar(TinyTool):
         prompt = \
             """
               - CREATE_EVENT: You can create a new event in your calendar. The content of the event has many fields, and you should use a JSON format to specify them. Here are the possible fields:
+                * date: The date of the event, in "YYYY-MM-DD" format. Mandatory.
                 * title: The title of the event. Mandatory.
                 * description: A brief description of the event. Optional.
+                * owner: The name of the person creating or owning the event. Optional.
                 * mandatory_attendees: A list of agent names who must attend the event. Optional.
                 * optional_attendees: A list of agent names who are invited to the event, but are not required to attend. Optional.
-                * start_time: The start time of the event. Optional.
-                * end_time: The end time of the event. Optional.
+                * start_time: The start time of the event, in "HH:MM" format (24-hour). Optional.
+                * end_time: The end time of the event, in "HH:MM" format (24-hour). Optional.
+              - FIND_EVENTS: You can search for events on a specific date. The content must be a JSON with these fields:
+                * year: The year to search (e.g., 2025). Mandatory.
+                * month: The month to search (1-12). Mandatory.
+                * day: The day to search (1-31). Mandatory.
+                * hour: Optional hour filter (0-23).
+                * minute: Optional minute filter (0-59).
+              - LIST_EVENTS: You can list all upcoming events in your calendar. Optionally, you can specify a JSON content with a "max_results" field to limit the number of events returned.
+              - DELETE_EVENT: You can delete an event from your calendar. The content must be a JSON with these fields:
+                * date: The date of the event to delete, in "YYYY-MM-DD" format. Mandatory.
+                * title: The title of the event to delete. Mandatory.
+                * start_time: Optional start time to disambiguate if multiple events have the same title.
             """
-        # TODO how the atendee list will be handled? How will they be notified of the invitation? I guess they must also have a calendar themselves. <-------------------------------------
+        # Attendee notification is handled in _process_action when a world reference is available.
+        # The world must be set via the constructor (world= parameter) for cross-agent notifications to work.
+        # Attendees receive a socialize() notification and both agents are made mutually accessible.
 
         return utils.dedent(prompt)
         
@@ -60,10 +230,17 @@ class TinyCalendar(TinyTool):
     def actions_constraints_prompt(self) -> str:
         prompt = \
             """
-              
+              - When you CREATE_EVENT, you **must** specify at least a title and a date in JSON format.
+              - The date **must** be a string in the format "YYYY-MM-DD".
+              - The start_time and end_time **must** be strings in the format "HH:MM" (24-hour format).
+              - The mandatory_attendees and optional_attendees, if provided, **must** be lists of agent names.
+              - When you include attendees in a CREATE_EVENT, those agents will be notified automatically if possible. If notification fails (e.g., agent not found), you will see a warning but the event is still created.
+              - You should CREATE_EVENT when you need to schedule a meeting, appointment, or any timed activity.
+              - You should FIND_EVENTS when you need to check what events exist on a particular date.
+              - You should LIST_EVENTS when you need an overview of all your upcoming events.
+              - You should DELETE_EVENT when an event is cancelled or no longer relevant.
             """
-            # TODO
 
-        return textwrap.dedent(prompt)
+        return utils.dedent(prompt)
     
 


### PR DESCRIPTION
## Summary

Complete rewrite of the TinyCalendar tool — from a broken stub with critical bugs to a fully functional calendar with 4 LLM action types.

## Changes

### Bug Fixes
- **Critical typo**: `self.calenar` → `self.calendar` (was creating a separate dict, causing silent data loss)
- **Dict unpacking bug**: `add_event(**event_content)` instead of `add_event(event_content)` (was passing dict as date parameter)
- **Missing validation keys**: Added `"date"` and `"owner"` to valid_keys in `_process_action`

### New Features
- **`find_events()`** — query events by date with optional hour/minute filtering
- **`list_events()`** — cross-date chronological listing with optional `max_results` limit
- **`delete_event()`** — remove events by title with optional `start_time` disambiguation; cleans up empty date keys
- **FIND_EVENTS**, **LIST_EVENTS**, **DELETE_EVENT** — three new LLM action types with full JSON validation
- **Attendee notification** — when a `world` reference is provided, attendees receive a `socialize()` notification and both agents are made mutually accessible
- **JSON serialization** — `"calendar"` added to `serializable_attributes` for full state persistence via `to_json()`/`from_json()`

### Prompt Improvements
- `actions_definitions_prompt` — documented all 4 action types with field descriptions and mandatory/optional annotations
- `actions_constraints_prompt` — replaced empty stub with 8 actionable constraints including format rules and usage guidance

### Code Quality
- Removed `# TODO under development` tag
- Removed unused `textwrap` import (replaced with `utils.dedent`)
- Added inline documentation for the attendee notification mechanism

### Tests
- 38 unit tests covering: initialization, CRUD operations, all 4 action types, serialization round-trip, ownership enforcement, invalid field validation, time filtering, and edge cases
- All 48 tests (38 calendar + 10 tool base) pass