### PR TITLE
Reject malformed JSON instead of treating it as empty

### DIFF
--- a/tests/unit/test_llm_chat.py
+++ b/tests/unit/test_llm_chat.py
@@ -428,6 +428,17 @@ class TestLLMChat:
         with pytest.raises(ValueError, match="Cannot convert"):
             chat._coerce_to_dict_or_list("42")  # valid JSON but not dict/list
 
+        for malformed in ("[{[}]", '{"name": }', "prefix {invalid} suffix"):
+            with pytest.raises(ValueError, match="Cannot convert"):
+                chat._coerce_to_dict_or_list(malformed)
+
+    def test_coerce_to_dict_or_list_accepts_empty_object(self):
+        """A valid empty JSON object must remain distinct from parse failure."""
+        chat = LLMChat(system_prompt="Test", user_prompt="Test")
+
+        assert chat._coerce_to_dict_or_list("{}") == {}
+        assert chat._coerce_to_dict_or_list("Here is the result:\n```json\n{ }\n```") == {}
+
     def test_coerce_to_list_valid_inputs(self):
         """Test list coercion with valid inputs."""
         chat = LLMChat(system_prompt="Test", user_prompt="Test")

--- a/tinytroupe/utils/llm.py
+++ b/tinytroupe/utils/llm.py
@@ -930,11 +930,10 @@ class LLMChat:
 
         try:
             result = utils.extract_json(llm_output)
-            # extract_json returns {} on failure, but we need dict or list
-            if result == {} and not (
-                isinstance(llm_output, str)
-                and ("{}" in llm_output or "{" in llm_output and "}" in llm_output)
-            ):
+            # extract_json returns {} both for a valid empty object and on parse
+            # failure. Only accept the former when the extracted payload itself
+            # is a valid empty JSON object; merely containing braces is not enough.
+            if result == {} and not self._contains_empty_json_object(llm_output):
                 raise ValueError(
                     "Cannot convert the LLM output to a dict or list value."
                 )
@@ -946,6 +945,20 @@ class LLMChat:
             return result
         except Exception:
             raise ValueError("Cannot convert the LLM output to a dict or list value.")
+
+    @staticmethod
+    def _contains_empty_json_object(llm_output: str) -> bool:
+        if not isinstance(llm_output, str):
+            return False
+
+        candidate = re.sub(r"^.*?({|\[)", r"\1", llm_output, flags=re.DOTALL)
+        candidate = re.sub(
+            r"(}|\])(?!.*(\]|})).*$", r"\1", candidate, flags=re.DOTALL
+        )
+        try:
+            return json.loads(candidate, strict=False) == {}
+        except (json.JSONDecodeError, TypeError):
+            return False
 
     def _request_dict_llm_message(self):
         return {


### PR DESCRIPTION
## Summary
- distinguish a valid empty JSON object from `extract_json`'s failure sentinel
- reject malformed model output that merely contains opening and closing braces
- cover valid empty objects and malformed object/list shapes with regression tests

## Testing
- `uv run --isolated --with pytest python -m pytest tests/unit/test_llm_chat.py -k coerce_to_dict_or_list -o addopts= -q` (3 passed)
- `python -m compileall -q tinytroupe/utils/llm.py`

Fixes #159